### PR TITLE
Support all CloudFlare's accepted record types

### DIFF
--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument("provider_name", help="specify the DNS provider to use", choices=providers)
     parser.add_argument("action", help="specify the action to take", default='list', choices=['create', 'list', 'update', 'delete'])
     parser.add_argument("domain", help="specify the domain, supports subdomains as well")
-    parser.add_argument("type", help="specify the entry type", default='TXT', choices=['A', 'CNAME', 'MX', 'SOA', 'TXT'])
+    parser.add_argument("type", help="specify the entry type", default='TXT', choices=['A', 'AAAA', 'CNAME', 'MX', 'NS', 'SPF', 'SOA', 'TXT', 'SRV', 'LOC'])
 
     parser.add_argument("--name", help="specify the record name")
     parser.add_argument("--content", help="specify the record content")


### PR DESCRIPTION
As per https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record there are a few more record types available from this provider, can't think of a reason to exclude them (acceptable lexicon options should include all types that are acceptable to at least one provider).