### PR TITLE
letsencrypt.sh hook script: work with TOKEN_VALUE starting with `-`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also install the latest version from the repository directly.
 ## Usage
 
 	$ lexicon -h
-	usage: cli.py [-h] [--name NAME] [--content=CONTENT] [--ttl=TTL]
+	usage: cli.py [-h] [--name=NAME] [--content=CONTENT] [--ttl=TTL]
 				  [--priority=PRIORITY] [--identifier=IDENTIFIER]
 				  [--auth-username=AUTH_USERNAME] [--auth-password=AUTH_PASSWORD]
 				  [--auth-token=AUTH_TOKEN] [--auth-otp-token=AUTH_OTP_TOKEN]

--- a/examples/letsencrypt.default.sh
+++ b/examples/letsencrypt.default.sh
@@ -13,7 +13,7 @@ function deploy_challenge {
 
     echo "deploy_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER create ${DOMAIN} TXT --name "_acme-challenge.${DOMAIN}." --content "${TOKEN_VALUE}"
+    lexicon $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
 
     sleep 30
 
@@ -40,7 +40,7 @@ function clean_challenge {
 
     echo "clean_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER delete ${DOMAIN} TXT --name "_acme-challenge.${DOMAIN}." --content "${TOKEN_VALUE}"
+    lexicon $PROVIDER delete ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
 
     # This hook is called after attempting to validate each domain,
     # whether or not validation was successful. Here you can delete
@@ -94,4 +94,4 @@ function unchanged_cert {
     #   The path of the file containing the intermediate certificate(s).
 }
 
-HANDLER=$1; shift; $HANDLER $@
+HANDLER=$1; shift; $HANDLER "$@"


### PR DESCRIPTION
I've seen the following situation:
```
deploy_challenge called: www.mathdown.com, 7tlqUzvkCQr4Q1BNc8kzLIr7jowITDhdPxRn3QgZ2XI, -EkW7ewZiy1HRpoc9ti6NrAely-SsAGbnhXh12yXje8
usage: lexicon [-h] [--name NAME] [--content CONTENT] [--ttl TTL]
               [--priority PRIORITY] [--identifier IDENTIFIER]
               [--auth-username AUTH_USERNAME] [--auth-password AUTH_PASSWORD]
               [--auth-token AUTH_TOKEN] [--auth-otp-token AUTH_OTP_TOKEN]
               {nsone,pointhq,dnsimple,dnspark,dnsmadeeasy,namesilo,rage4,cloudflare,easydns}
               {create,list,update,delete} domain
               {A,AAAA,CNAME,MX,NS,SPF,SOA,TXT,SRV,LOC}
lexicon: error: argument --content: expected one argument
```

AFAICT this is a clear bug in argparse.  If `--option` takes a (non-optional)
argument, it should consume the next argument no matter what it looks like,
e.g. `--option -whatever+@%!`.
It's been reported since 2010 [https://bugs.python.org/issue9334] but met resistance; there is a patch with opt-in fix but even that hasn't been merged.

Fortunately, argparse reliably accepts `--option=-foo` syntax.

Also fixed $@ -> "$@".  Probably makes no difference
(don't think args provided by letsencrypt can contain spaces)
but the only reason to use $@ over $* is its 1:1 expansion in "$@"...