### PR TITLE
cron support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,15 @@ RUN echo "test.intranet.example.com" > /srv/letsencrypt/domains.txt
 
 CMD ["/srv/letsencrypt/letsencrypt.sh", "--cron", "--hook", "/srv/letsencrypt/letsencrypt.default.sh", "--challenge", "dns-01"]
 #CMD /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01
+
+RUN \
+  apt-get update && \
+  apt-get install -y rsyslog && \
+  rm -rf /var/lib/apt/lists/*
+  
+COPY ./examples/crontab /etc/crontab
+RUN crontab /etc/crontab
+COPY ./examples/cron.sh /srv/letsencrypt/cron.sh
+RUN chmod +x /srv/letsencrypt/cron.sh
+RUN touch /var/log/cron
+CMD [ "/srv/letsencrypt/cron.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
-FROM phusion/baseimage
+FROM python:2
 MAINTAINER Jason Kulatunga <jason@thesparktree.com>
 
 # Install Letsencrypt.sh deps + python deps + requests package deps
-RUN \
-  apt-get update && \
-  apt-get install -y build-essential python-dev curl git nano wget libffi-dev libssl-dev && \
-  rm -rf /var/lib/apt/lists/*
+#RUN \
+#  apt-get update && \
+#  apt-get install -y build-essential python-dev curl git nano wget libffi-dev libssl-dev && \
+#  rm -rf /var/lib/apt/lists/*
 
 
 # Install pip
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python2.7
+#RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python2.7
 
 # Clone letsencrypt.sh repo
-RUN cd /srv && git clone --depth 1 https://github.com/lukas2511/letsencrypt.sh.git letsencrypt
-RUN chmod +x /srv/letsencrypt/letsencrypt.sh
+RUN git clone --depth 1 https://github.com/lukas2511/letsencrypt.sh.git /srv/letsencrypt
+#RUN chmod +x /srv/letsencrypt/letsencrypt.sh
 
 # Copy hooks
 COPY ./examples/letsencrypt.default.sh /srv/letsencrypt/letsencrypt.default.sh
-RUN chmod +x /srv/letsencrypt/letsencrypt.default.sh
+#RUN chmod +x /srv/letsencrypt/letsencrypt.default.sh
 
 # Install dns-lexicon
-RUN pip install requests[security]
-RUN pip install dns-lexicon
+RUN pip install requests[security] dns-lexicon
 
 # Create letsencrypt domains.txt file.
 RUN echo "test.intranet.example.com" > /srv/letsencrypt/domains.txt
@@ -30,10 +29,13 @@ RUN echo "test.intranet.example.com" > /srv/letsencrypt/domains.txt
 CMD ["/srv/letsencrypt/letsencrypt.sh", "--cron", "--hook", "/srv/letsencrypt/letsencrypt.default.sh", "--challenge", "dns-01"]
 #CMD /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01
 
-RUN \
-  apt-get update && \
-  apt-get install -y rsyslog && \
-  rm -rf /var/lib/apt/lists/*
+#RUN \
+#  apt-get update && \
+#  apt-get install -y rsyslog && \
+#  rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get -y install cron rsyslog
+RUN sed -i 's/session    required     pam_loginuid.so/#session    required     pam_loginuid.so/' /etc/pam.d/cron
   
 COPY ./examples/crontab /etc/crontab
 RUN crontab /etc/crontab

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 
 
 # Install pip
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python2.7
 
 # Clone letsencrypt.sh repo
 RUN cd /srv && git clone --depth 1 https://github.com/lukas2511/letsencrypt.sh.git letsencrypt

--- a/examples/cron.sh
+++ b/examples/cron.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+env > /etc/profile
 rsyslogd
 cron
 tail -F /var/log/syslog /var/log/cron

--- a/examples/cron.sh
+++ b/examples/cron.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+rsyslogd
+cron
+tail -F /var/log/syslog /var/log/cron

--- a/examples/cron.sh
+++ b/examples/cron.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-env > /etc/profile
+env > /etc/environment
 rsyslogd
 cron
 tail -F /var/log/syslog /var/log/cron

--- a/examples/crontab
+++ b/examples/crontab
@@ -1,0 +1,2 @@
+@reboot /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1 
+@monthly /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1

--- a/examples/crontab
+++ b/examples/crontab
@@ -1,2 +1,2 @@
-@reboot . /etc/profile; /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1 
-@monthly . /etc/profile; /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1
+@reboot env - `cat /etc/environment` /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1
+@monthly env - `cat /etc/environment` /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1

--- a/examples/crontab
+++ b/examples/crontab
@@ -1,3 +1,2 @@
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-@reboot /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1 
-@monthly /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1
+@reboot . /etc/profile; /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1 
+@monthly . /etc/profile; /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1

--- a/examples/crontab
+++ b/examples/crontab
@@ -1,2 +1,3 @@
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 @reboot /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1 
 @monthly /srv/letsencrypt/letsencrypt.sh --cron --hook /srv/letsencrypt/letsencrypt.default.sh --challenge dns-01 >> /var/log/cron 2>&1


### PR DESCRIPTION
since letsencrypt certs is only valid for 90days, manually run it for one-shot is useless.
there is a dockerfile with cron support, it will request(re-new) certs on run and on every 1st day of month 
consider put it in a separate branch

it could be build as a docker image tag like lexicon:cron

btw:
could you release lexicon docker image auto-build in dockerhub?