### PR TITLE
remove sudo in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN \
 
 
 # Install pip
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python2.7
 
 # Clone letsencrypt.sh repo
 RUN cd /srv && git clone --depth 1 https://github.com/lukas2511/letsencrypt.sh.git letsencrypt


### PR DESCRIPTION
```
Step 4 : RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7
 ---> Running in 5f096a611077
/bin/sh: 1: sudo: not found
curl: (23) Failed writing body (1830 != 2759)
ERROR: Service 'letsencrypt' failed to build: The command '/bin/sh -c curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | sudo python2.7' returned a non-zero code: 127
```