### PR TITLE
make sure we can specify the TTL for a provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Potential providers are as follows. If you would like to contribute one, please 
 - AuroraDNS ([docs](https://www.pcextreme.com/aurora/dns))
 - AHNames ([docs](https://ahnames.com/en/resellers?tab=2))
 - AWS Route53 ([docs](https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html))
-- BuddyDNS ([docs](https://www.buddyns.com/support/api/v2/))
-- ClouDNS ([docs](https://www.cloudns.net/wiki/article/56/))
-- DurableDNS ([docs](https://durabledns.com/wiki/doku.php/ddns))
+- ~~BuddyDNS ([docs](https://www.buddyns.com/support/api/v2/))~~ 
+- ~~ClouDNS ([docs](https://www.cloudns.net/wiki/article/56/))~~ Requires paid account
+- ~~DurableDNS ([docs](https://durabledns.com/wiki/doku.php/ddns))~~ Can't set TXT records
 - Dyn ([docs](https://help.dyn.com/dns-api-knowledge-base/))
 - EntryDNS ([docs](https://entrydns.net/help))
 - Google Cloud DNS ([docs](https://cloud.google.com/dns/api/v1/))

--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -16,7 +16,7 @@ def BaseProviderParser():
 
     parser.add_argument("--name", help="specify the record name")
     parser.add_argument("--content", help="specify the record content")
-    parser.add_argument("--ttl", help="specify the record time-to-live")
+    parser.add_argument("--ttl", type=int, help="specify the record time-to-live")
     parser.add_argument("--priority", help="specify the record priority")
     parser.add_argument("--identifier", help="specify the record for update or delete actions")
     return parser

--- a/lexicon/providers/base.py
+++ b/lexicon/providers/base.py
@@ -2,6 +2,7 @@ class Provider(object):
     def __init__(self, options):
         self.provider_name = 'example',
         self.options = options
+        self.default_ttl = 3600
 
     # Authenicate against provider,
     # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
@@ -70,3 +71,4 @@ class Provider(object):
             # some providers have quotes around the TXT records, so we're going to remove those extra quotes
             record['content'] = record['content'][1:-1]
         return record
+

--- a/lexicon/providers/cloudflare.py
+++ b/lexicon/providers/cloudflare.py
@@ -30,7 +30,10 @@ class Provider(BaseProvider):
 
     # Create record. If record already exists with the same content, do nothing'
     def create_record(self, type, name, content):
-        payload = self._post('/zones/{0}/dns_records'.format(self.domain_id), {'type': type, 'name': self._full_name(name), 'content': content})
+        data = {'type': type, 'name': self._full_name(name), 'content': content}
+        if self.options['ttl']:
+            data['ttl'] = self.options['ttl']
+        payload = self._post('/zones/{0}/dns_records'.format(self.domain_id), data)
 
         print 'create_record: {0}'.format(payload['success'])
         return payload['success']
@@ -73,6 +76,8 @@ class Provider(BaseProvider):
             data['name'] = self._full_name(name)
         if content:
             data['content'] = content
+        if self.options['ttl']:
+            data['ttl'] = self.options['ttl']
 
         payload = self._put('/zones/{0}/dns_records/{1}'.format(self.domain_id, identifier), data)
 

--- a/lexicon/providers/cloudflare.py
+++ b/lexicon/providers/cloudflare.py
@@ -31,8 +31,8 @@ class Provider(BaseProvider):
     # Create record. If record already exists with the same content, do nothing'
     def create_record(self, type, name, content):
         data = {'type': type, 'name': self._full_name(name), 'content': content}
-        if self.options['ttl']:
-            data['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
         payload = self._post('/zones/{0}/dns_records'.format(self.domain_id), data)
 
         print 'create_record: {0}'.format(payload['success'])
@@ -76,8 +76,8 @@ class Provider(BaseProvider):
             data['name'] = self._full_name(name)
         if content:
             data['content'] = content
-        if self.options['ttl']:
-            data['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
 
         payload = self._put('/zones/{0}/dns_records/{1}'.format(self.domain_id, identifier), data)
 

--- a/lexicon/providers/cloudxns.py
+++ b/lexicon/providers/cloudxns.py
@@ -36,8 +36,10 @@ class Provider(BaseProvider):
             'host': self._relative_name(name),
             'value': content,
             'type': type,
-            'line_id': 1
+            'line_id': 1,
         }
+        if self.options['ttl']:
+            record['ttl'] = self.options['ttl']
 
         payload = self._post('/record', record)
 
@@ -92,6 +94,8 @@ class Provider(BaseProvider):
             'value': content,
             'type': type
         }
+        if self.options['ttl']:
+            data['ttl'] = self.options['ttl']
 
         payload = self._put('/record/' + identifier, data)
 

--- a/lexicon/providers/cloudxns.py
+++ b/lexicon/providers/cloudxns.py
@@ -38,8 +38,8 @@ class Provider(BaseProvider):
             'type': type,
             'line_id': 1,
         }
-        if self.options['ttl']:
-            record['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            record['ttl'] = self.options.get('ttl')
 
         payload = self._post('/record', record)
 
@@ -94,8 +94,8 @@ class Provider(BaseProvider):
             'value': content,
             'type': type
         }
-        if self.options['ttl']:
-            data['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
 
         payload = self._put('/record/' + identifier, data)
 

--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -34,8 +34,8 @@ class Provider(BaseProvider):
                         'content': content
                     }
                 }
-        if self.options['ttl']:
-            record['record']['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            record['record']['ttl'] = self.options.get('ttl')
         payload = {}
         try:
             payload = self._post('/domains/{0}/records'.format(self.domain_id), record)
@@ -81,8 +81,8 @@ class Provider(BaseProvider):
             data['record']['name'] = self._relative_name(name)
         if content:
             data['record']['content'] = content
-        if self.options['ttl']:
-            data['record']['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['record']['ttl'] = self.options.get('ttl')
 
         payload = self._put('/domains/{0}/records/{1}'.format(self.domain_id, identifier), data)
 

--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -34,6 +34,8 @@ class Provider(BaseProvider):
                         'content': content
                     }
                 }
+        if self.options['ttl']:
+            record['record']['ttl'] = self.options['ttl']
         payload = {}
         try:
             payload = self._post('/domains/{0}/records'.format(self.domain_id), record)
@@ -79,6 +81,8 @@ class Provider(BaseProvider):
             data['record']['name'] = self._relative_name(name)
         if content:
             data['record']['content'] = content
+        if self.options['ttl']:
+            data['record']['ttl'] = self.options['ttl']
 
         payload = self._put('/domains/{0}/records/{1}'.format(self.domain_id, identifier), data)
 

--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -34,7 +34,7 @@ class Provider(BaseProvider):
             'type': type,
             'name': self._relative_name(name),
             'value': content,
-            'ttl': 86400
+            'ttl': self.options.get('ttl',300)
         }
         payload = {}
         try:
@@ -79,7 +79,7 @@ class Provider(BaseProvider):
 
         data = {
             'id': identifier,
-            'ttl': 86400
+            'ttl': self.options.get('ttl',300)
         }
 
         if name:

--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -34,7 +34,7 @@ class Provider(BaseProvider):
             'type': type,
             'name': self._relative_name(name),
             'value': content,
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
         payload = {}
         try:
@@ -79,7 +79,7 @@ class Provider(BaseProvider):
 
         data = {
             'id': identifier,
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
 
         if name:

--- a/lexicon/providers/dnspark.py
+++ b/lexicon/providers/dnspark.py
@@ -74,7 +74,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
         if type:
             data['rtype'] = type

--- a/lexicon/providers/dnspark.py
+++ b/lexicon/providers/dnspark.py
@@ -74,7 +74,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': 300
+            'ttl': self.options.get('ttl',300)
         }
         if type:
             data['rtype'] = type

--- a/lexicon/providers/dnspod.py
+++ b/lexicon/providers/dnspod.py
@@ -33,6 +33,8 @@ class Provider(BaseProvider):
             'record_line': '默认',
             'value': content
         }
+        if self.options['ttl']:
+            record['ttl'] = self.options['ttl']
 
         payload = self._post('/Record.Create', record)
 
@@ -83,6 +85,8 @@ class Provider(BaseProvider):
             'record_line': '默认',
             'value': content
         }
+        if self.options['ttl']:
+            data['ttl'] = self.options['ttl']
         print data
         payload = self._post('/Record.Modify', data)
         print payload

--- a/lexicon/providers/dnspod.py
+++ b/lexicon/providers/dnspod.py
@@ -33,8 +33,8 @@ class Provider(BaseProvider):
             'record_line': '默认',
             'value': content
         }
-        if self.options['ttl']:
-            record['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            record['ttl'] = self.options.get('ttl')
 
         payload = self._post('/Record.Create', record)
 
@@ -85,8 +85,8 @@ class Provider(BaseProvider):
             'record_line': '默认',
             'value': content
         }
-        if self.options['ttl']:
-            data['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
         print data
         payload = self._post('/Record.Modify', data)
         print payload

--- a/lexicon/providers/easydns.py
+++ b/lexicon/providers/easydns.py
@@ -30,7 +30,7 @@ class Provider(BaseProvider):
             'type': type,
             'domain': self.domain_id,
             'host': self._relative_name(name),
-            'ttl': 300,
+            'ttl': self.options.get('ttl',300),
             'prio': 0,
             'rdata': content
         }
@@ -77,7 +77,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': 300
+            'ttl': self.options.get('ttl',300)
         }
         if type:
             data['type'] = type

--- a/lexicon/providers/easydns.py
+++ b/lexicon/providers/easydns.py
@@ -30,7 +30,7 @@ class Provider(BaseProvider):
             'type': type,
             'domain': self.domain_id,
             'host': self._relative_name(name),
-            'ttl': self.options.get('ttl',300),
+            'ttl': self.options.get('ttl',self.default_ttl),
             'prio': 0,
             'rdata': content
         }
@@ -77,7 +77,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
         if type:
             data['type'] = type

--- a/lexicon/providers/luadns.py
+++ b/lexicon/providers/luadns.py
@@ -27,7 +27,7 @@ class Provider(BaseProvider):
 
     # Create record. If record already exists with the same content, do nothing'
     def create_record(self, type, name, content):
-        payload = self._post('/zones/{0}/records'.format(self.domain_id), {'type': type, 'name': self._fqdn_name(name), 'content': content, 'ttl': self.options.get('ttl',300)})
+        payload = self._post('/zones/{0}/records'.format(self.domain_id), {'type': type, 'name': self._fqdn_name(name), 'content': content, 'ttl': self.options.get('ttl',self.default_ttl)})
 
         print 'create_record: {0}'.format(True)
         return True
@@ -63,7 +63,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
         if type:
             data['type'] = type

--- a/lexicon/providers/luadns.py
+++ b/lexicon/providers/luadns.py
@@ -27,7 +27,7 @@ class Provider(BaseProvider):
 
     # Create record. If record already exists with the same content, do nothing'
     def create_record(self, type, name, content):
-        payload = self._post('/zones/{0}/records'.format(self.domain_id), {'type': type, 'name': self._fqdn_name(name), 'content': content, 'ttl': 300})
+        payload = self._post('/zones/{0}/records'.format(self.domain_id), {'type': type, 'name': self._fqdn_name(name), 'content': content, 'ttl': self.options.get('ttl',300)})
 
         print 'create_record: {0}'.format(True)
         return True
@@ -63,7 +63,7 @@ class Provider(BaseProvider):
     def update_record(self, identifier, type=None, name=None, content=None):
 
         data = {
-            'ttl': 300
+            'ttl': self.options.get('ttl',300)
         }
         if type:
             data['type'] = type

--- a/lexicon/providers/namesilo.py
+++ b/lexicon/providers/namesilo.py
@@ -27,8 +27,8 @@ class Provider(BaseProvider):
             'rrtype': type,
             'rrvalue': content
         }
-        if self.options['ttl']:
-            record['rrttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            record['rrttl'] = self.options.get('ttl')
         payload = self._get('/dnsAddRecord', record)
         print 'create_record: {0}'.format(True)
         return True
@@ -74,8 +74,8 @@ class Provider(BaseProvider):
             data['rrhost'] = self._relative_name(name)
         if content:
             data['rdata'] = content
-        if self.options['ttl']:
-            data['rrttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['rrttl'] = self.options.get('ttl')
 
         payload = self._get('/dnsUpdateRecord', data)
 

--- a/lexicon/providers/namesilo.py
+++ b/lexicon/providers/namesilo.py
@@ -27,6 +27,8 @@ class Provider(BaseProvider):
             'rrtype': type,
             'rrvalue': content
         }
+        if self.options['ttl']:
+            record['rrttl'] = self.options['ttl']
         payload = self._get('/dnsAddRecord', record)
         print 'create_record: {0}'.format(True)
         return True
@@ -72,6 +74,8 @@ class Provider(BaseProvider):
             data['rrhost'] = self._relative_name(name)
         if content:
             data['rdata'] = content
+        if self.options['ttl']:
+            data['rrttl'] = self.options['ttl']
 
         payload = self._get('/dnsUpdateRecord', data)
 

--- a/lexicon/providers/rage4.py
+++ b/lexicon/providers/rage4.py
@@ -30,6 +30,9 @@ class Provider(BaseProvider):
             'content': content,
             'type': type
         }
+        if self.options['ttl']:
+            record['ttl'] = self.options['ttl']
+
         payload = {}
         try:
             payload = self._post('/createrecord/',{},record)
@@ -78,6 +81,8 @@ class Provider(BaseProvider):
             data['name'] = self._full_name(name)
         if content:
             data['content'] = content
+        if self.options['ttl']:
+            data['ttl'] = self.options['ttl']
         # if type:
         #     raise 'Type updating is not supported by this provider.'
 

--- a/lexicon/providers/rage4.py
+++ b/lexicon/providers/rage4.py
@@ -30,8 +30,8 @@ class Provider(BaseProvider):
             'content': content,
             'type': type
         }
-        if self.options['ttl']:
-            record['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            record['ttl'] = self.options.get('ttl')
 
         payload = {}
         try:
@@ -81,8 +81,8 @@ class Provider(BaseProvider):
             data['name'] = self._full_name(name)
         if content:
             data['content'] = content
-        if self.options['ttl']:
-            data['ttl'] = self.options['ttl']
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
         # if type:
         #     raise 'Type updating is not supported by this provider.'
 

--- a/lexicon/providers/vultr.py
+++ b/lexicon/providers/vultr.py
@@ -51,7 +51,7 @@ class Provider(BaseProvider):
             processed_record = {
                 'type': record['type'],
                 'name': "{0}.{1}".format(record['name'], self.domain_id),
-                'ttl': record.get('ttl', 300),
+                'ttl': record.get('ttl', self.options.get('ttl',300)),
                 'content': record['data'],
                 'id': record['RECORDID']
             }
@@ -74,7 +74,7 @@ class Provider(BaseProvider):
         data = {
             'domain': self.domain_id,
             'RECORDID': identifier,
-            'ttl': 300
+            'ttl': self.options.get('ttl',300)
         }
         # if type:
         #     data['type'] = type

--- a/lexicon/providers/vultr.py
+++ b/lexicon/providers/vultr.py
@@ -34,6 +34,8 @@ class Provider(BaseProvider):
             record['data'] = "\"{0}\"".format(content)
         else:
             record['data'] = content
+        if self.options.get('ttl'):
+            record['ttl'] = self.options.get('ttl')
         payload = self._post('/dns/create_record', record)
 
         print 'create_record: {0}'.format(True)
@@ -51,7 +53,7 @@ class Provider(BaseProvider):
             processed_record = {
                 'type': record['type'],
                 'name': "{0}.{1}".format(record['name'], self.domain_id),
-                'ttl': record.get('ttl', self.options.get('ttl',300)),
+                'ttl': record.get('ttl', self.options.get('ttl',self.default_ttl)),
                 'content': record['data'],
                 'id': record['RECORDID']
             }
@@ -74,7 +76,7 @@ class Provider(BaseProvider):
         data = {
             'domain': self.domain_id,
             'RECORDID': identifier,
-            'ttl': self.options.get('ttl',300)
+            'ttl': self.options.get('ttl',self.default_ttl)
         }
         # if type:
         #     data['type'] = type

--- a/tests/fixtures/cassettes/cloudflare/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/cloudflare/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.cloudflare.com/client/v4/zones?status=active&name=capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"result":[{"id":"fac516c650e5a737bdc3e1e3dc1047f3","name":"capsulecd.com","status":"active","paused":false,"type":"full","development_mode":0,"name_servers":["dawn.ns.cloudflare.com","owen.ns.cloudflare.com"],"original_name_servers":["ns1glr.name.com","ns2bls.name.com","ns3nrz.name.com","ns4hny.name.com"],"original_registrar":null,"original_dnshost":null,"modified_on":"2016-07-30T20:59:34.628808Z","created_on":"2016-03-09T07:39:40.476430Z","meta":{"step":4,"wildcard_proxiable":false,"custom_certificate_quota":0,"page_rule_quota":3,"phishing_detected":false,"multiple_railguns_allowed":false},"owner":{"type":"user","id":"521a961001d9333c8191f53a9f70eb31","email":"darkmethodz@gmail.com"},"permissions":["#analytics:read","#billing:edit","#billing:read","#cache_purge:edit","#dns_records:edit","#dns_records:read","#lb:edit","#lb:read","#logs:read","#organization:edit","#organization:read","#ssl:edit","#ssl:read","#waf:edit","#waf:read","#zone:edit","#zone:read","#zone_settings:edit","#zone_settings:read"],"plan":{"id":"0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee","name":"Free
+        Website","price":0,"currency":"USD","frequency":"","legacy_id":"free","legacy_discount":false,"is_subscribed":null,"can_subscribe":null,"externally_managed":false}}],"result_info":{"page":1,"per_page":20,"total_pages":1,"count":1,"total_count":1},"success":true,"errors":[],"messages":[]}'}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      cf-ray: [2cabd520f7ad2840-SJC]
+      connection: [keep-alive]
+      content-length: ['1365']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:16:35 GMT']
+      expires: ['Sun, 25 Jan 1981 05:00:00 GMT']
+      pragma: [no-cache]
+      server: [cloudflare-nginx]
+      set-cookie: ['__cfduid=dd9d24e707e22b025cd9a50565acc2e7b1469913395; expires=Sun,
+          30-Jul-17 21:16:35 GMT; path=/; domain=.cloudflare.com; HttpOnly']
+      strict-transport-security: [max-age=31536000]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"content": "ttlshouldbe3600", "type": "TXT", "name": "ttl.fqdn.capsulecd.com",
+      "ttl": 3600}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['92']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.cloudflare.com/client/v4/zones/fac516c650e5a737bdc3e1e3dc1047f3/dns_records
+  response:
+    body: {string: !!python/unicode '{"result":{"id":"d8228669d592e95dae643af3f02b3121","type":"TXT","name":"ttl.fqdn.capsulecd.com","content":"ttlshouldbe3600","proxiable":false,"proxied":false,"ttl":3600,"locked":false,"zone_id":"fac516c650e5a737bdc3e1e3dc1047f3","zone_name":"capsulecd.com","modified_on":"2016-07-30T21:16:37.708905Z","created_on":"2016-07-30T21:16:37.708905Z","meta":{"auto_added":false}},"success":true,"errors":[],"messages":[]}'}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      cf-ray: [2cabd52f886e2840-SJC]
+      connection: [keep-alive]
+      content-length: ['414']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:16:37 GMT']
+      expires: ['Sun, 25 Jan 1981 05:00:00 GMT']
+      pragma: [no-cache]
+      server: [cloudflare-nginx]
+      set-cookie: ['__cfduid=dc4936330fb57b49d96db3db72b9c73471469913397; expires=Sun,
+          30-Jul-17 21:16:37 GMT; path=/; domain=.cloudflare.com; HttpOnly']
+      strict-transport-security: [max-age=31536000]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.cloudflare.com/client/v4/zones/fac516c650e5a737bdc3e1e3dc1047f3/dns_records?per_page=100&type=TXT&name=ttl.fqdn.capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"result":[{"id":"d8228669d592e95dae643af3f02b3121","type":"TXT","name":"ttl.fqdn.capsulecd.com","content":"ttlshouldbe3600","proxiable":false,"proxied":false,"ttl":3600,"locked":false,"zone_id":"fac516c650e5a737bdc3e1e3dc1047f3","zone_name":"capsulecd.com","modified_on":"2016-07-30T21:16:37.708905Z","created_on":"2016-07-30T21:16:37.708905Z","meta":{"auto_added":false}}],"result_info":{"page":1,"per_page":100,"total_pages":1,"count":1,"total_count":1},"success":true,"errors":[],"messages":[]}'}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      cf-ray: [2cabd53e19080669-SJC]
+      connection: [keep-alive]
+      content-length: ['498']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:16:40 GMT']
+      expires: ['Sun, 25 Jan 1981 05:00:00 GMT']
+      pragma: [no-cache]
+      server: [cloudflare-nginx]
+      set-cookie: ['__cfduid=dc94c57a150fef3b606be0709cb6fed481469913400; expires=Sun,
+          30-Jul-17 21:16:40 GMT; path=/; domain=.cloudflare.com; HttpOnly']
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudxns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/cloudxns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"login_token": "c34e4c5a884101c4c2be3737af8d3d08,81d216fcd15eeb53", "format":
+      "json"}'
+    headers:
+      API-FORMAT: [json]
+      API-HMAC: [60d4f1dcba8c9ca4be5765da8013798f]
+      API-KEY: [c34e4c5a884101c4c2be3737af8d3d08]
+      API-REQUEST-DATE: ['Sat Jul 30 14:17:51 2016']
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://www.cloudxns.net/api2/domain
+  response:
+    body: {string: !!python/unicode '{"code":1,"message":"success","total":"1","data":[{"id":"89415","domain":"capsulecd.com.","status":"ok","level":"3","take_over_status":"no","create_time":"2016-06-08
+        14:49:10","update_time":"2016-07-31 05:00:05","ttl":"600"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['226']
+      content-type: [text/html; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:17:52 GMT']
+      server: [Tengine]
+      set-cookie: ['CloudXNS_TOKEN=51fea81f44602db1d2e5b802389e290f; expires=Sun,
+          31-Jul-2016 07:17:52 GMT; path=/']
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"format": "json", "login_token": "c34e4c5a884101c4c2be3737af8d3d08,81d216fcd15eeb53",
+      "value": "ttlshouldbe3600", "line_id": 1, "host": "ttl.fqdn", "ttl": 3600, "type":
+      "TXT", "domain_id": "89415"}'
+    headers:
+      API-FORMAT: [json]
+      API-HMAC: [e0c9b4324d37554aa5484bc07b5f9ab5]
+      API-KEY: [c34e4c5a884101c4c2be3737af8d3d08]
+      API-REQUEST-DATE: ['Sat Jul 30 14:18:35 2016']
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['198']
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://www.cloudxns.net/api2/record
+  response:
+    body: {string: !!python/unicode '{"code":1,"message":"success","record_id":[1598051]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['52']
+      content-type: [text/html; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:36 GMT']
+      server: [Tengine]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"login_token": "c34e4c5a884101c4c2be3737af8d3d08,81d216fcd15eeb53", "format":
+      "json"}'
+    headers:
+      API-FORMAT: [json]
+      API-HMAC: [b7935f975dabe3a7edc65c58c8357570]
+      API-KEY: [c34e4c5a884101c4c2be3737af8d3d08]
+      API-REQUEST-DATE: ['Sat Jul 30 14:18:53 2016']
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['86']
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://www.cloudxns.net/api2/record/89415?host_id=0&row_num=2000&offset=0
+  response:
+    body: {string: !!python/unicode '{"code":1,"message":"success","total":"13","offset":0,"row_num":2000,"data":[{"record_id":"1373545","host_id":"1155553","host":"docs","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"docs.example.com.","ttl":"600","type":"CNAME","status":"ok","create_time":"2016-06-08
+        15:15:00","update_time":"2016-06-08 15:15:00"},{"record_id":"1373543","host_id":"1155551","host":"localhost","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"127.0.0.1","ttl":"600","type":"A","status":"ok","create_time":"2016-06-08
+        15:14:58","update_time":"2016-06-08 15:14:58"},{"record_id":"1373561","host_id":"1155569","host":"random.fqdntest","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:15","update_time":"2016-06-08 15:15:15"},{"record_id":"1373563","host_id":"1155571","host":"random.fulltest","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:17","update_time":"2016-06-08 15:15:17"},{"record_id":"1373565","host_id":"1155573","host":"random.test","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:19","update_time":"2016-06-08 15:15:19"},{"record_id":"1598051","host_id":"1368285","host":"ttl.fqdn","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"ttlshouldbe3600\"","ttl":"3600","type":"TXT","status":"ok","create_time":"2016-07-31
+        05:18:36","update_time":"2016-07-31 05:18:36"},{"record_id":"1598049","host_id":"1368283","host":"ttlrecord.fqdn","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"ttlshouldbe500\"","ttl":"500","type":"TXT","status":"ok","create_time":"2016-07-31
+        05:00:05","update_time":"2016-07-31 05:00:05"},{"record_id":"1373567","host_id":"1155583","host":"updated.test","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:16:23","update_time":"2016-06-08 15:16:23"},{"record_id":"1373569","host_id":"1155585","host":"updated.testfqdn","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:16:25","update_time":"2016-06-08 15:16:25"},{"record_id":"1373571","host_id":"1155587","host":"updated.testfull","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:16:28","update_time":"2016-06-08 15:16:28"},{"record_id":"1373547","host_id":"1155555","host":"_acme-challenge.fqdn","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:02","update_time":"2016-06-08 15:15:02"},{"record_id":"1373549","host_id":"1155557","host":"_acme-challenge.full","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:04","update_time":"2016-06-08 15:15:04"},{"record_id":"1373551","host_id":"1155559","host":"_acme-challenge.test","line_id":"1","line_zh":"\u5168\u7f51\u9ed8\u8ba4","line_en":"DEFAULT","mx":null,"value":"\"challengetoken\"","ttl":"600","type":"TXT","status":"ok","create_time":"2016-06-08
+        15:15:07","update_time":"2016-06-08 15:15:07"}]}'}
+    headers:
+      connection: [keep-alive]
+      content-length: ['3825']
+      content-type: [text/html; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:54 GMT']
+      server: [Tengine]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/dnsimple/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/dnsimple/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.sandbox.dnsimple.com/v1/domains/capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"domain":{"id":6259,"user_id":null,"registrant_id":603,"account_id":241,"name":"capsulecd.com","unicode_name":"capsulecd.com","token":"yyMtxjkT67RPyEvy6t9UT6CgIYOSzj8u","state":"registered","lockable":true,"auto_renew":false,"whois_protected":false,"record_count":17,"service_count":0,"expires_on":"2017-03-16","created_at":"2016-03-16T06:14:11.347Z","updated_at":"2016-07-28T13:25:33.167Z"}}'}
+    headers:
+      access-control-allow-headers: ['Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with']
+      access-control-allow-methods: ['GET,POST,PUT,DELETE,OPTIONS']
+      access-control-allow-origin: ['*']
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [keep-alive]
+      content-length: ['393']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:17:55 GMT']
+      etag: [W/"2b7e5f861f5a9611caaf3f8314223e03"]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [DENY]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [92809576-2150-43bf-90e9-5d28c3fc09c5]
+      x-runtime: ['0.086946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"record": {"content": "ttlshouldbe3600", "record_type": "TXT", "name":
+      "ttl.fqdn", "ttl": 3600}}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['97']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.sandbox.dnsimple.com/v1/domains/capsulecd.com/records
+  response:
+    body: {string: !!python/unicode '{"record":{"id":231859,"domain_id":6259,"parent_id":null,"name":"ttl.fqdn","content":"ttlshouldbe3600","ttl":3600,"prio":null,"record_type":"TXT","system_record":false,"created_at":"2016-07-30T21:18:39.228Z","updated_at":"2016-07-30T21:18:39.228Z"}}'}
+    headers:
+      access-control-allow-headers: ['Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with']
+      access-control-allow-methods: ['GET,POST,PUT,DELETE,OPTIONS']
+      access-control-allow-origin: ['*']
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [keep-alive]
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:39 GMT']
+      etag: [W/"ec91b5f66cdc15a087c7e4f4e31e50a9"]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [DENY]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [8e41d750-74ba-4704-84d2-7b8ac545e098]
+      x-runtime: ['0.320641']
+      x-xss-protection: [1; mode=block]
+    status: {code: 201, message: Created}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.sandbox.dnsimple.com/v1/domains/capsulecd.com/records?type=TXT&name=ttl.fqdn
+  response:
+    body: {string: !!python/unicode '[{"record":{"id":231859,"domain_id":6259,"parent_id":null,"name":"ttl.fqdn","content":"ttlshouldbe3600","ttl":3600,"prio":null,"record_type":"TXT","system_record":false,"created_at":"2016-07-30T21:18:39.228Z","updated_at":"2016-07-30T21:18:39.228Z"}}]'}
+    headers:
+      access-control-allow-headers: ['Authorization,Accepts,Content-Type,X-DNSimple-Token,X-DNSimple-Domain-Token,X-CSRF-Token,x-requested-with']
+      access-control-allow-methods: ['GET,POST,PUT,DELETE,OPTIONS']
+      access-control-allow-origin: ['*']
+      cache-control: ['max-age=0, private, must-revalidate']
+      connection: [keep-alive]
+      content-length: ['251']
+      content-type: [application/json; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:39 GMT']
+      etag: [W/"46b59f4c682d9bd80f0ce66bf36ca229"]
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-download-options: [noopen]
+      x-frame-options: [DENY]
+      x-permitted-cross-domain-policies: [none]
+      x-request-id: [b3b9c81d-a2b3-4757-90c5-fe2c25244f07]
+      x-runtime: ['0.038856']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,73 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:17:56 GMT']
+    method: GET
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1469912667781}'}
+    headers:
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:17:57 GMT']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=C3E1EC43F205291DE2EFCEC754AE1C9B; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [da2c0e9b-acfe-41ad-9bdc-fde691cd05a2]
+      x-dnsme-requestlimit: ['150']
+      x-dnsme-requestsremaining: ['149']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"type": "TXT", "name": "ttl.fqdn", "value": "ttlshouldbe3600", "ttl":
+      3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:17:57 GMT']
+    method: POST
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
+  response:
+    body: {string: !!python/unicode '{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10123501,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
+    headers:
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:18:03 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10123501']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=5F6B2969090A00FE4785EF306D0FB721; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [cc0f497c-2e88-4e8a-852f-78a4320aefae]
+      x-dnsme-requestlimit: ['150']
+      x-dnsme-requestsremaining: ['148']
+    status: {code: 201, message: Created}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:18:02 GMT']
+    method: GET
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=ttl.fqdn&type=TXT
+  response:
+    body: {string: !!python/unicode '{"data":[{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10123501,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
+    headers:
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:18:03 GMT']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A4E269008AB4A100D6747658D5B1EED6; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [3c968cd1-fc2a-466a-940d-de689c423751]
+      x-dnsme-requestlimit: ['150']
+      x-dnsme-requestsremaining: ['147']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/easydns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/easydns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://sandbox.rest.easydns.net/domain/easydnstemp.com?format=json
+  response:
+    body: {string: !!python/unicode '
+
+
+        {"msg":"OK","tm":1469913500,"data":{"id":"easydnstemp.com","domain":"easydnstemp.com","exists":"Y","onsystem":"Y","expiry":"2017-04-04","next_due":"2017-04-04","cloned_to":"NONE","service":"19","sub_block":"NONE"},"status":200}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['x-requested-with, Content-Type, origin, authorization,
+          accept, client-security-token, HTTP_X_HTTP_METHOD_OVERRIDE, X-AUTH_COMBINED,
+          X-AUTHTOKEN, X-RSP']
+      access-control-allow-methods: ['POST, GET, OPTIONS, DELETE, PUT']
+      access-control-allow-origin: ['"*"']
+      cache-control: ['no-cache, must-revalidate']
+      connection: [close]
+      content-length: ['229']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:18:20 GMT']
+      expires: ['0']
+      pragma: [no-cache]
+      server: [Apache/2.2.16 (Debian)]
+      set-cookie: [easyAPI=crn2ip8vg9nnga7ndudfdbacf7; path=/, 'api_token=api_579d199c416fa6.90017739;
+          expires=Sat, 30-Jul-2016 21:33:20 GMT; path=/; domain=sandbox.rest.easydns.net']
+      vary: [Accept-Encoding]
+      x-powered-by: [PHP/5.3.3-7+squeeze28]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"domain": "easydnstemp.com", "prio": 0, "ttl": 3600, "host": "ttl.fqdn",
+      "rdata": "ttlshouldbe3600", "type": "TXT"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: PUT
+    uri: http://sandbox.rest.easydns.net/zones/records/add/easydnstemp.com/TXT?format=json
+  response:
+    body: {string: !!python/unicode '
+
+
+        {"msg":"OK","tm":1469913523,"data":{"host":"ttl.fqdn","geozone_id":0,"ttl":3600,"prio":0,"rdata":"ttlshouldbe3600","revoked":0,"id":"30108531","new_host":"ttl.fqdn.easydnstemp.com"},"status":201}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['x-requested-with, Content-Type, origin, authorization,
+          accept, client-security-token, HTTP_X_HTTP_METHOD_OVERRIDE, X-AUTH_COMBINED,
+          X-AUTHTOKEN, X-RSP']
+      access-control-allow-methods: ['POST, GET, OPTIONS, DELETE, PUT']
+      access-control-allow-origin: ['"*"']
+      cache-control: ['no-cache, must-revalidate']
+      connection: [close]
+      content-length: ['197']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:18:43 GMT']
+      expires: ['0']
+      pragma: [no-cache]
+      server: [Apache/2.2.16 (Debian)]
+      set-cookie: [easyAPI=5va09p3461ti1itm6m1im14v25; path=/, 'api_token=api_579d19b39299a2.96331053;
+          expires=Sat, 30-Jul-2016 21:33:43 GMT; path=/; domain=sandbox.rest.easydns.net']
+      vary: [Accept-Encoding]
+      x-powered-by: [PHP/5.3.3-7+squeeze28]
+    status: {code: 201, message: Created}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://sandbox.rest.easydns.net/zones/records/all/easydnstemp.com?format=json
+  response:
+    body: {string: !!python/unicode '
+
+
+        {"tm":1469913540,"data":[{"id":"28453449","domain":"easydnstemp.com","host":"random.fqdntest","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453450","domain":"easydnstemp.com","host":"random.fulltest","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453454","domain":"easydnstemp.com","host":"updated.testfull","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453451","domain":"easydnstemp.com","host":"random.test","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453452","domain":"easydnstemp.com","host":"updated.test","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453453","domain":"easydnstemp.com","host":"updated.testfqdn","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453447","domain":"easydnstemp.com","host":"_acme-challenge.full","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453441","domain":"easydnstemp.com","host":"@","ttl":"0","prio":"0","type":"MX","rdata":"LOCAL.","geozone_id":"0","last_mod":"2016-04-04
+        11:53:42"},{"id":"28453443","domain":"easydnstemp.com","host":"www","ttl":"0","prio":"0","type":"CNAME","rdata":"easydnstemp.com.","geozone_id":"0","last_mod":"2016-04-04
+        13:41:56"},{"id":"28453442","domain":"easydnstemp.com","host":"@","ttl":"0","prio":"0","type":"A","rdata":"PARK","geozone_id":"0","last_mod":"2016-04-04
+        13:41:56"},{"id":"28453439","domain":"easydnstemp.com","host":"@","ttl":"0","prio":null,"type":"NS","rdata":"LOCAL.","geozone_id":"0","last_mod":"2016-04-04
+        11:53:42"},{"id":"28453444","domain":"easydnstemp.com","host":"localhost","ttl":"300","prio":"0","type":"A","rdata":"127.0.0.1","geozone_id":"0","last_mod":"2016-04-04
+        13:41:56"},{"id":"28453445","domain":"easydnstemp.com","host":"docs","ttl":"300","prio":"0","type":"CNAME","rdata":"docs.example.com","geozone_id":"0","last_mod":"2016-04-04
+        13:41:56"},{"id":"28453446","domain":"easydnstemp.com","host":"_acme-challenge.fqdn","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"28453440","domain":"easydnstemp.com","host":"@","ttl":"0","prio":null,"type":"SOA","rdata":"dns1.easydns.com.
+        zone.easydns.com. %%NOW%% 3600 600 604800 10800","geozone_id":"0","last_mod":"2016-04-04
+        11:53:42"},{"id":"28453448","domain":"easydnstemp.com","host":"_acme-challenge.test","ttl":"300","prio":"0","type":"TXT","rdata":"challengetoken","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"30108530","domain":"easydnstemp.com","host":"ttlrecord.fqdn","ttl":"500","prio":"0","type":"TXT","rdata":"ttlshouldbe500","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"},{"id":"30108531","domain":"easydnstemp.com","host":"ttl.fqdn","ttl":"3600","prio":"0","type":"TXT","rdata":"ttlshouldbe3600","geozone_id":"0","last_mod":"2016-07-30
+        17:18:43"}],"count":18,"total":18,"start":0,"max":1000,"status":200}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['x-requested-with, Content-Type, origin, authorization,
+          accept, client-security-token, HTTP_X_HTTP_METHOD_OVERRIDE, X-AUTH_COMBINED,
+          X-AUTHTOKEN, X-RSP']
+      access-control-allow-methods: ['POST, GET, OPTIONS, DELETE, PUT']
+      access-control-allow-origin: ['"*"']
+      cache-control: ['no-cache, must-revalidate']
+      connection: [close]
+      content-length: ['3275']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:19:00 GMT']
+      expires: ['0']
+      pragma: [no-cache]
+      server: [Apache/2.2.16 (Debian)]
+      set-cookie: [easyAPI=2busmdcp11akqbgges9d0ksaq5; path=/, 'api_token=api_579d19c4168ff5.36053273;
+          expires=Sat, 30-Jul-2016 21:34:00 GMT; path=/; domain=sandbox.rest.easydns.net']
+      vary: [Accept-Encoding]
+      x-powered-by: [PHP/5.3.3-7+squeeze28]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/luadns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/luadns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.luadns.com/v1/zones
+  response:
+    body: {string: !!python/unicode '[{"id":39105,"name":"capsulecd.com","template_id":0,"synced":true,"queries_count":0,"records_count":17,"aliases_count":0,"redirects_count":0,"forwards_count":0}]'}
+    headers:
+      cache-control: ['no-cache, no-store, must-revalidate']
+      connection: [keep-alive]
+      content-length: ['161']
+      content-type: [application/json; charset=UTF-8]
+      date: ['Sat, 30 Jul 2016 21:18:23 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      keep-alive: [timeout=10]
+      pragma: [no-cache]
+      server: [nginx]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"content": "ttlshouldbe3600", "type": "TXT", "name": "ttl.fqdn.capsulecd.com.",
+      "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['93']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.luadns.com/v1/zones/39105/records
+  response:
+    body: {string: !!python/unicode '{"id":23375012,"name":"ttl.fqdn.capsulecd.com.","type":"TXT","content":"ttlshouldbe3600","ttl":3600,"zone_id":39105,"generated":false,"created_at":"2016-07-30T21:18:23.944202567Z","updated_at":"2016-07-30T21:18:23.944203059Z"}'}
+    headers:
+      cache-control: ['no-cache, no-store, must-revalidate']
+      connection: [keep-alive]
+      content-length: ['226']
+      content-type: [application/json; charset=UTF-8]
+      date: ['Sat, 30 Jul 2016 21:18:23 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      keep-alive: [timeout=10]
+      pragma: [no-cache]
+      server: [nginx]
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.luadns.com/v1/zones/39105/records
+  response:
+    body: {string: !!python/unicode '[{"id":23375012,"name":"ttl.fqdn.capsulecd.com.","type":"TXT","content":"ttlshouldbe3600","ttl":3600,"zone_id":39105,"generated":false,"created_at":"2016-07-30T21:18:23.944203Z","updated_at":"2016-07-30T21:18:23.944203Z"},{"id":23374769,"name":"ttlrecord.fqdn.capsulecd.com.","type":"TXT","content":"ttlshouldbe500","ttl":500,"zone_id":39105,"generated":false,"created_at":"2016-07-30T21:02:35.758225Z","updated_at":"2016-07-30T21:02:35.758226Z"},{"id":23373229,"name":"updated.testfull.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:19:05.912934Z","updated_at":"2016-07-30T19:19:13.123781Z"},{"id":23373228,"name":"updated.testfqdn.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:19:04.558279Z","updated_at":"2016-07-30T19:19:10.409676Z"},{"id":23373227,"name":"updated.test.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:19:03.199578Z","updated_at":"2016-07-30T19:19:09.760395Z"},{"id":23373165,"name":"random.test.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:18.567473Z","updated_at":"2016-07-30T19:15:18.567474Z"},{"id":23373164,"name":"random.fulltest.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:17.188586Z","updated_at":"2016-07-30T19:15:17.188587Z"},{"id":23373163,"name":"random.fqdntest.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:15.831438Z","updated_at":"2016-07-30T19:15:15.831439Z"},{"id":23373159,"name":"_acme-challenge.test.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:04.022172Z","updated_at":"2016-07-30T19:15:04.022173Z"},{"id":23373158,"name":"_acme-challenge.full.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:03.146476Z","updated_at":"2016-07-30T19:15:03.146476Z"},{"id":23373157,"name":"_acme-challenge.fqdn.capsulecd.com.","type":"TXT","content":"challengetoken","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:02.18588Z","updated_at":"2016-07-30T19:15:02.18588Z"},{"id":23373156,"name":"localhost.capsulecd.com.","type":"A","content":"127.0.0.1","ttl":300,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:15:01.232355Z","updated_at":"2016-07-30T19:15:01.232355Z"},{"id":23373137,"name":"capsulecd.com.","type":"NS","content":"ns5.luadns.net.","ttl":86400,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.463466Z","updated_at":"2016-07-30T19:13:48.463467Z"},{"id":23373136,"name":"capsulecd.com.","type":"NS","content":"ns4.luadns.net.","ttl":86400,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.463465Z","updated_at":"2016-07-30T19:13:48.463465Z"},{"id":23373135,"name":"capsulecd.com.","type":"NS","content":"ns3.luadns.net.","ttl":86400,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.463463Z","updated_at":"2016-07-30T19:13:48.463464Z"},{"id":23373134,"name":"capsulecd.com.","type":"NS","content":"ns2.luadns.net.","ttl":86400,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.463462Z","updated_at":"2016-07-30T19:13:48.463462Z"},{"id":23373133,"name":"capsulecd.com.","type":"NS","content":"ns1.luadns.net.","ttl":86400,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.46346Z","updated_at":"2016-07-30T19:13:48.46346Z"},{"id":23373132,"name":"capsulecd.com.","type":"SOA","content":"ns1.luadns.net.
+        hostmaster.luadns.com. 1469913504 1200 120 604800 3600","ttl":3600,"zone_id":39105,"generated":false,"created_at":"2016-07-30T19:13:48.463456Z","updated_at":"2016-07-30T19:13:48.463456Z"}]'}
+    headers:
+      cache-control: ['no-cache, no-store, must-revalidate']
+      connection: [keep-alive]
+      content-length: ['4027']
+      content-type: [application/json; charset=UTF-8]
+      date: ['Sat, 30 Jul 2016 21:18:24 GMT']
+      expires: ['Thu, 01 Jan 1970 00:00:00 GMT']
+      keep-alive: [timeout=10]
+      pragma: [no-cache]
+      server: [nginx]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namesilo/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/namesilo/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://sandbox.namesilo.com/api/getDomainInfo?domain=capsulecdfake.com&type=xml&version=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0"?>
+
+        <namesilo><request><operation>getDomainInfo</operation><ip>208.72.142.184</ip></request><reply><code>300</code><detail>success</detail><created>2016-04-02</created><expires>2018-04-02</expires><status></status><locked>Yes</locked><private>Yes</private><auto_renew>Yes</auto_renew><traffic_type>Parked</traffic_type><forward_url>N/A</forward_url><forward_type>N/A</forward_type><nameservers><nameserver
+        position="1">NS1.NAMESILO.COM</nameserver><nameserver position="2">NS2.NAMESILO.COM</nameserver></nameservers><contact_ids><registrant>1321</registrant><administrative>1321</administrative><technical>1321</technical><billing>1321</billing></contact_ids></reply></namesilo>
+
+        '}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      connection: [keep-alive]
+      content-length: ['697']
+      content-type: [text/xml]
+      date: ['Sat, 30 Jul 2016 21:18:25 GMT']
+      expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+      pragma: [no-cache]
+      server: [nginx]
+      set-cookie: [PHPSESSID=e8cf685910ae02021c385a2745168050; path=/; domain=dev.namesilo.com]
+      vary: [Accept-Encoding]
+      x-proxy-cache: [MISS]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://sandbox.namesilo.com/api/dnsAddRecord?domain=capsulecdfake.com&rrhost=ttl.fqdn&rrttl=3600&rrtype=TXT&rrvalue=ttlshouldbe3600&type=xml&version=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0"?>
+
+        <namesilo><request><operation>dnsAddRecord</operation><ip>208.72.142.184</ip></request><reply><code>300</code><detail>success</detail><record_id>fbdb16fc843289c9fb95191c45d5c418</record_id></reply></namesilo>
+
+        '}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      connection: [keep-alive]
+      content-length: ['231']
+      content-type: [text/xml]
+      date: ['Sat, 30 Jul 2016 21:18:46 GMT']
+      expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+      pragma: [no-cache]
+      server: [nginx]
+      set-cookie: [PHPSESSID=4239b39f04384c456b18f08a3cbcbffc; path=/; domain=dev.namesilo.com]
+      vary: [Accept-Encoding]
+      x-proxy-cache: [MISS]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: http://sandbox.namesilo.com/api/dnsListRecords?domain=capsulecdfake.com&type=xml&version=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0"?>
+
+        <namesilo><request><operation>dnsListRecords</operation><ip>208.72.142.184</ip></request><reply><code>300</code><detail>success</detail><resource_record><record_id>94e84ad42c54cbdcb04b8fd687b018ab</record_id><type>A</type><host>capsulecdfake.com</host><value>107.161.23.204</value><ttl>172816</ttl><distance>0</distance></resource_record><resource_record><record_id>e41467dcfde58d9f2574f09bcd4ffd3e</record_id><type>A</type><host>capsulecdfake.com</host><value>164.132.212.72</value><ttl>172816</ttl><distance>0</distance></resource_record><resource_record><record_id>ab6da0965e2d0e0129dda0b5bcd2359a</record_id><type>A</type><host>capsulecdfake.com</host><value>167.114.213.199</value><ttl>172816</ttl><distance>0</distance></resource_record><resource_record><record_id>b318260397dd3e024bedb73f3eeee938</record_id><type>A</type><host>localhost.capsulecdfake.com</host><value>127.0.0.1</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>f8bcfa159c3386ea456bb083036a10f5</record_id><type>CNAME</type><host>docs.capsulecdfake.com</host><value>docs.example.com</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>127343b7a5dbf264063e8a811f81f671</record_id><type>CNAME</type><host>www.capsulecdfake.com</host><value>parking.namesilo.com</value><ttl>172816</ttl><distance>0</distance></resource_record><resource_record><record_id>fa0e471f4fa90492c408e48622472ea0</record_id><type>TXT</type><host>random.fqdntest.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>8262ed73b91378ddb4619b4bfa8cf0e9</record_id><type>TXT</type><host>random.fulltest.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>0be072e325c133a6404b50d4db16d4eb</record_id><type>TXT</type><host>random.test.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>fbdb16fc843289c9fb95191c45d5c418</record_id><type>TXT</type><host>ttl.fqdn.capsulecdfake.com</host><value>ttlshouldbe3600</value><ttl>3600</ttl><distance>0</distance></resource_record><resource_record><record_id>cb67f7f2f3ca6c75e8da9e4635646ff3</record_id><type>TXT</type><host>ttlrecord.fqdn.capsulecdfake.com</host><value>ttlshouldbe500</value><ttl>3600</ttl><distance>0</distance></resource_record><resource_record><record_id>17d0324d66c9429946eb51b6b5d47c15</record_id><type>TXT</type><host>updated.test.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>8d3545eb96823643a10ff7e52a1b7e00</record_id><type>TXT</type><host>updated.testfqdn.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>ea749f964ed0c55c0b7186c197811135</record_id><type>TXT</type><host>updated.testfull.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>8bc1c2ab7721caa67c40464bc715dfd9</record_id><type>TXT</type><host>_acme-challenge.fqdn.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>74618129e89eaf753d104e49b2f2f55b</record_id><type>TXT</type><host>_acme-challenge.full.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record><resource_record><record_id>7ebc06ef3977aef104d2c4133b597bf4</record_id><type>TXT</type><host>_acme-challenge.test.capsulecdfake.com</host><value>challengetoken</value><ttl>7200</ttl><distance>0</distance></resource_record></reply></namesilo>
+
+        '}
+    headers:
+      cache-control: ['no-store, no-cache, must-revalidate, post-check=0, pre-check=0']
+      connection: [keep-alive]
+      content-length: ['3818']
+      content-type: [text/xml]
+      date: ['Sat, 30 Jul 2016 21:19:02 GMT']
+      expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+      pragma: [no-cache]
+      server: [nginx]
+      set-cookie: [PHPSESSID=74fc784842f94e5bc96b0396949c9bcc; path=/; domain=dev.namesilo.com]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-proxy-cache: [MISS]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/rage4/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/rage4/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://rage4.com/rapi/getdomainbyname/?name=capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"id":57039,"name":"capsulecd.com","owner_email":"lexicon@mailinator.com","type":0,"subnet_mask":0,"default_ns1":"ns1.r4ns.com","default_ns2":"ns2.r4ns.net","soa_refresh":10800,"soa_expiry":604800,"soa_retry":3600,"soa_nx":3600,"ns_ttl":3600}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: ['private, s-maxage=0']
+      content-length: ['242']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:29 GMT']
+      server: [GBSHouse/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload;]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://rage4.com/rapi/createrecord/?content=ttlshouldbe3600&ttl=3600&type=TXT&id=57039&name=ttl.fqdn.capsulecd.com
+  response:
+    body: {string: !!python/unicode '{"status":true,"id":2111095,"error":""}'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: ['private, s-maxage=0']
+      content-length: ['39']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:29 GMT']
+      server: [GBSHouse/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload;]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://rage4.com/rapi/getrecords/?id=57039&name=ttl.fqdn.capsulecd.com
+  response:
+    body: {string: !!python/unicode '[{"id":2111095,"name":"ttl.fqdn.capsulecd.com","content":"ttlshouldbe3600","type":"TXT","ttl":3600,"priority":1,"domain_id":57039,"geo_region_id":0,"geo_lat":0.0,"geo_long":0.0,"failover_enabled":false,"failover_active":false,"failover_content":null,"failover_withdraw":false,"webhook_id":-1,"is_active":true,"udp_limit":false,"description":null}]'}
+    headers:
+      access-control-allow-origin: ['*']
+      cache-control: ['private, s-maxage=0']
+      content-length: ['347']
+      content-type: [text/plain; charset=utf-8]
+      date: ['Sat, 30 Jul 2016 21:18:31 GMT']
+      server: [GBSHouse/2.0]
+      strict-transport-security: [max-age=31536000; includeSubDomains; preload;]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/vultr/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/vultr/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.vultr.com/v1/dns/list
+  response:
+    body: {string: !!python/unicode '[{"domain":"capsulecd.com","date_created":"2016-04-13
+        19:03:44"}]'}
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-length: ['65']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:23:16 GMT']
+      expires: ['Sat, 30 Jul 2016 21:23:15 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
+    status: {code: 200, message: OK}
+- request:
+    body: domain=capsulecd.com&name=ttl.fqdn&type=TXT&priority=0&ttl=3600&data=%22ttlshouldbe3600%22
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.9.1]
+    method: POST
+    uri: https://api.vultr.com/v1/dns/create_record
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-length: ['0']
+      content-type: [text/html; charset=UTF-8]
+      date: ['Sat, 30 Jul 2016 21:23:18 GMT']
+      expires: ['Sat, 30 Jul 2016 21:23:17 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.9.1]
+    method: GET
+    uri: https://api.vultr.com/v1/dns/records?domain=capsulecd.com
+  response:
+    body: {string: !!python/unicode '[{"type":"A","name":"localhost","data":"127.0.0.1","priority":0,"RECORDID":2051670,"ttl":300},{"type":"CNAME","name":"docs","data":"docs.example.com","priority":0,"RECORDID":2051671,"ttl":300},{"type":"TXT","name":"random.fqdntest","data":"\"challengetoken\"","priority":0,"RECORDID":2051680,"ttl":300},{"type":"TXT","name":"random.fulltest","data":"\"challengetoken\"","priority":0,"RECORDID":2051681,"ttl":300},{"type":"TXT","name":"random.test","data":"\"challengetoken\"","priority":0,"RECORDID":2051682,"ttl":300},{"type":"TXT","name":"ttl.fqdn","data":"\"ttlshouldbe3600\"","priority":0,"RECORDID":2452603,"ttl":3600},{"type":"TXT","name":"updated.test","data":"\"challengetoken\"","priority":0,"RECORDID":2051716,"ttl":300},{"type":"TXT","name":"updated.testfqdn","data":"\"challengetoken\"","priority":0,"RECORDID":2051717,"ttl":300},{"type":"TXT","name":"updated.testfull","data":"\"challengetoken\"","priority":0,"RECORDID":2051718,"ttl":300},{"type":"TXT","name":"_acme-challenge.full","data":"\"challengetoken\"","priority":0,"RECORDID":2051668,"ttl":300}]'}
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-length: ['1068']
+      content-type: [application/json]
+      date: ['Sat, 30 Jul 2016 21:23:19 GMT']
+      expires: ['Sat, 30 Jul 2016 21:23:18 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      transfer-encoding: [chunked]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -160,6 +160,20 @@ class IntegrationTests():
             assert records[0]['type'] == 'TXT'
             assert records[0]['name'] == 'random.fqdntest.{0}'.format(self.domain)
 
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        with provider_vcr.use_cassette(self._cassette_path('IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml'), filter_headers=self._filter_headers(), filter_query_parameters=self._filter_query_parameters(), filter_post_data_parameters=self._filter_post_data_parameters()):
+            provider = self.Provider({
+                'domain': self.domain,
+                'auth_username': self._auth_username(),
+                'auth_token': self._auth_token(),
+                'ttl': 3600
+            }, self.provider_opts)
+            provider.authenticate()
+            assert provider.create_record('TXT',"ttl.fqdn.{0}.".format(self.domain),'ttlshouldbe3600')
+            records = provider.list_records('TXT','ttl.fqdn.{0}'.format(self.domain))
+            assert len(records) == 1
+            assert str(records[0]['ttl']) == str(3600)
+
     @pytest.mark.skip(reason="not sure how to test empty list across multiple providers")
     def test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found(self):
         with provider_vcr.use_cassette(self._cassette_path('IntegrationTests/test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found.yaml'), filter_headers=self._filter_headers(), filter_query_parameters=self._filter_query_parameters(), filter_post_data_parameters=self._filter_post_data_parameters()):

--- a/tests/providers/test_digitalocean.py
+++ b/tests/providers/test_digitalocean.py
@@ -14,3 +14,7 @@ class DigitalOceanProviderTests(TestCase, IntegrationTests):
     domain = 'capsulecd.com'
     def _filter_headers(self):
         return ['Authorization']
+
+    @pytest.mark.skip(reason="can not set ttl when creating/updating records")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return

--- a/tests/providers/test_dnspark.py
+++ b/tests/providers/test_dnspark.py
@@ -14,3 +14,8 @@ class DnsParkProviderTests(TestCase, IntegrationTests):
     domain = 'capsulecd.com'
     def _filter_headers(self):
         return ['Authorization']
+
+    #TODO:
+    @pytest.mark.skip(reason="domain no longer exists")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return

--- a/tests/providers/test_dnspod.py
+++ b/tests/providers/test_dnspod.py
@@ -14,3 +14,8 @@ class DnsParkProviderTests(TestCase, IntegrationTests):
     domain = 'capsulecd.com'
     def _filter_post_data_parameters(self):
         return ['login_token']
+
+    # TODO:
+    @pytest.mark.skip(reason="domain no longer exists")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return

--- a/tests/providers/test_gandi.py
+++ b/tests/providers/test_gandi.py
@@ -2,6 +2,7 @@
 from lexicon.providers.gandi import Provider
 from integration_tests import IntegrationTests
 from unittest import TestCase
+import pytest
 
 # Hook into testing framework by inheriting unittest.TestCase and reuse
 # the tests which *each and every* implementation of the interface must
@@ -12,3 +13,7 @@ class GandiProviderTests(TestCase, IntegrationTests):
     provider_name = 'gandi'
     domain = 'xtestingx.com'
     provider_opts = {'api_endpoint': 'https://rpc.ote.gandi.net/xmlrpc/'}
+
+    @pytest.mark.skip(reason="can not set ttl when creating/updating records")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return

--- a/tests/providers/test_nsone.py
+++ b/tests/providers/test_nsone.py
@@ -14,3 +14,7 @@ class Ns1ProviderTests(TestCase, IntegrationTests):
     domain = 'capsulecd.com'
     def _filter_headers(self):
         return ['X-NSONE-Key', 'Authorization']
+
+    @pytest.mark.skip(reason="can not set ttl when creating/updating records")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return

--- a/tests/providers/test_pointhq.py
+++ b/tests/providers/test_pointhq.py
@@ -14,3 +14,7 @@ class PointHqProviderTests(TestCase, IntegrationTests):
     domain = 'capsulecd.com'
     def _filter_headers(self):
         return ['Authorization']
+
+    @pytest.mark.skip(reason="can not set ttl when creating/updating records")
+    def test_Provider_when_calling_list_records_after_setting_ttl(self):
+        return


### PR DESCRIPTION
This PR fixes #49 and ensures that we can correctly specify the TTL for a record when creating/updating it. Sets a default TTL of 3600s (60 minutes) which is standardized across all providers and more reasonable than 86400 which was hardcoded in some providers previously