### PR TITLE
Add TransIP support

### DIFF
--- a/lexicon/providers/base.py
+++ b/lexicon/providers/base.py
@@ -4,7 +4,7 @@ class Provider(object):
         self.options = options
         self.default_ttl = 3600
 
-    # Authenicate against provider,
+    # Authenticate against provider,
     # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
     # Should throw an error if authentication fails for any reason, of if the domain does not exist.
     def authenticate(self):
@@ -71,4 +71,3 @@ class Provider(object):
             # some providers have quotes around the TXT records, so we're going to remove those extra quotes
             record['content'] = record['content'][1:-1]
         return record
-

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -73,6 +73,9 @@ class Provider(BaseProvider):
 
     # Update a record. Identifier must be specified.
     def update_record(self, identifier=None, type=None, name=None, content=None):
+        if not (type or name or content):
+            raise StandardError("At least one of type, name or content must be specified.")
+
         all_records = self.list_records(show_output=False)
         filtered_records = self._filter_records(all_records, type, name)
 
@@ -97,6 +100,9 @@ class Provider(BaseProvider):
     # If record does not exist, do nothing.
     # If an identifier is specified, use it, otherwise do a lookup using type, name and content.
     def delete_record(self, identifier=None, type=None, name=None, content=None):
+        if not (type or name or content):
+            raise StandardError("At least one of type, name or content must be specified.")
+
         all_records = self.list_records(show_output=False)
         filtered_records = self._filter_records(all_records, type, name, content)
 

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -63,6 +63,12 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         raise NotImplementedError("Providers should implement this!")
 
+    def _relative_name(self, record_name):
+        name = super(Provider, self)._relative_name(record_name)
+        if not name:
+            name = "@"
+        return name
+
     def _filter_records(self, records, type=None, name=None, content=None):
         _records = []
         for record in records:

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import
+from .base import Provider as BaseProvider
+from transip.client import DomainClient
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-username", help="specify username used to authenticate")
+    subparser.add_argument("--auth-api-key", help="specify API private key to authenticate")
+    subparser.add_argument("--auth-ca-bundle", help="specify CA bundle to use to verify API SSL certificate")
+
+
+class Provider(BaseProvider):
+    def __init__(self, options):
+        super(Provider, self).__init__(options)
+        self.provider_name = 'transip'
+        self.domain_id = None
+        username = self.options.get('auth_username')
+        key_file = self.options.get('auth_api_key')
+
+        if not username or not key_file:
+            raise StandardError("No username and/or keyfile was specified")
+
+        self.client = DomainClient(
+            username=username,
+            key_file=key_file,
+            mode="readonly",
+            cacert=self.options.get('auth_ca_bundle', False)
+        )
+
+    # Authenticate against provider,
+    # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
+    # Should throw an error if authentication fails for any reason, of if the domain does not exist.
+    def authenticate(self):
+        ## This request will fail when the domain does not exist,
+        ## allowing us to check for existence
+        self.client.getInfo(self.options.get('domain'))
+
+    # Create record. If record already exists with the same content, do nothing'
+    def create_record(self, type, name, content):
+        raise NotImplementedError("Providers should implement this!")
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        records = self._filter_records(
+            records=self.client.getInfo(self.options.get('domain')).dnsEntries,
+            type=type,
+            name=name,
+            content=content
+        )
+
+        print 'list_records: {0}'.format(records)
+        return records
+
+    # Update a record. Identifier must be specified.
+    def update_record(self, identifier, type=None, name=None, content=None):
+        raise NotImplementedError("Providers should implement this!")
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    # If an identifier is specified, use it, otherwise do a lookup using type, name and content.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        raise NotImplementedError("Providers should implement this!")
+
+    def _filter_records(self, records, type=None, name=None, content=None):
+        _records = []
+        for record in records:
+            if (not type or record.type == type) and \
+               (not name or record.name == self._relative_name(name)) and \
+               (not content or record.content == content):
+                _records.append({
+                    "name": record.name,
+                    "type": record.type,
+                    "content": record.content,
+                    "ttl": record.expire
+                })
+        return _records

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -23,7 +23,7 @@ class Provider(BaseProvider):
         self.client = DomainClient(
             username=username,
             key_file=key_file,
-            mode="readonly",
+            mode="readwrite",
             cacert=self.options.get('auth_ca_bundle', False)
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests[security]
 tldextract
+transip

--- a/setup.py
+++ b/setup.py
@@ -111,5 +111,9 @@ setup(
             'lexicon=lexicon.__main__:main',
         ],
     },
+
+    extras_require={
+        'transip': ['transip']
+    },
     test_suite='tests'
 )


### PR DESCRIPTION
I added support for the TransIP API based on my own transip library.

I ran into one problem though: the TransIP API does not specify IDs per record. This means that the implementation of `update_record` and `delete_record` can't use `identifier`, and only the `type`, `content` and `name` parameters. I'm not sure how to handle this, for now I just ignore the identifier parameter.

I also added an extras_require section to setup.py, to easily install the dependencies with `pip install lexicon[transip]`