### PR TITLE
verified that default ttl 3600 works with all dnsmadeeasy integration…

### DIFF
--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_authenticate.yaml
@@ -8,18 +8,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:58:56 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:09 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459045687231,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:10 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=5E12F54092D4FF53CEE0FFF576513598; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [2fd4f129-4f1f-4589-8368-070ffa108ccf]
+      set-cookie: [JSESSIONID=342BF3D0CF1A60BD7985B286A6BE9471; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [95ac709b-98ab-44a1-b5bd-d0f143dcc1f3]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['149']
+      x-dnsme-requestsremaining: ['91']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -8,50 +8,50 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:09 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=thisisadomainidonotown.com
   response:
     body: {string: !!python/unicode "\r\n\r\n\r\n\r\n\r\n\r\n\r\n<!DOCTYPE html>\r\
         \n<html>\r\n<head>\r\n\t<title>Management Console</title>\r\n\t\r\n\r\n\r\n\
-        \    <meta charset=\"utf-8\" />\r\n\r\n\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/ui.jqgrid.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.multiselect.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.multiselect.filter.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.jqplot.min.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.dataTables.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\t\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/console.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" />\r\n\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/dnsme.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" title=\"dnsme\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/custom-theme/jquery-ui-1.8.14.custom.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" title=\"dnsme\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.fancybox-1.3.4.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ type=\"text/css\" media=\"screen\" />\r\n    <link rel=\"stylesheet\" href='/V2.0/css/realtime-stats/realtime-stats-chart.css;jsessionid=E58D035061346B05CE29B3F890F30681'\
+        \    <meta charset=\"utf-8\" />\r\n\r\n\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/ui.jqgrid.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.multiselect.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.multiselect.filter.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.jqplot.min.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.dataTables.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\t\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/console.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" />\r\n\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/dnsme.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" title=\"dnsme\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/custom-theme/jquery-ui-1.8.14.custom.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" title=\"dnsme\" />\r\n\t<link rel=\"stylesheet\" href='/V2.0/css/jquery.fancybox-1.3.4.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ type=\"text/css\" media=\"screen\" />\r\n    <link rel=\"stylesheet\" href='/V2.0/css/realtime-stats/realtime-stats-chart.css;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
         \ type=\"text/css\" media=\"screen\" />\r\n\r\n\t<script type=\"text/javascript\"\
-        \ src='/V2.0/js/jquery-1.6.2.min.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery-ui-1.8.16.custom.min.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.cookie.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/i18n/grid.locale-en.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.jqGrid.min.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.validate.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.populate.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.dropdownPlain.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.metadata.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.multiselect.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.multiselect.filter.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.diff.min.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.tinysort.min.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.fancybox-1.3.4.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.dataTables.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\t\r\n\t\r\n\t<script type=\"text/javascript\" src='/V2.0/js/date.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
+        \ src='/V2.0/js/jquery-1.6.2.min.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery-ui-1.8.16.custom.min.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.cookie.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/i18n/grid.locale-en.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.jqGrid.min.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.validate.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.populate.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.dropdownPlain.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.metadata.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.multiselect.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.multiselect.filter.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.diff.min.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.tinysort.min.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.fancybox-1.3.4.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.dataTables.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\t\r\n\t\r\n\t<script type=\"text/javascript\" src='/V2.0/js/date.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
         \ ></script>\r\n    <script>Date.now = function() { return +new Date; };</script>\r\
-        \n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.pagination.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.blockUI.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/highcharts.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n\r\n    <script type=\"text/javascript\" src='/V2.0/js/console.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
+        \n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.pagination.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/jquery.blockUI.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\r\n\t<script type=\"text/javascript\" src='/V2.0/js/highcharts.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n\r\n    <script type=\"text/javascript\" src='/V2.0/js/console.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
         \ ></script>\r\n\r\n    <script>\r\n        var require = {\r\n          \
         \  config: {\r\n                'DataStore' : {\r\n                    baseUrl:\
-        \ '/V2.0/realtimestats;jsessionid=E58D035061346B05CE29B3F890F30681'\r\n  \
+        \ '/V2.0/realtimestats;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\r\n  \
         \              }\r\n            }\r\n        }\r\n    </script>\r\n    \r\n\
-        <script type=\"text/javascript\" src='/V2.0/js/realtimestats/libs/requirejs/require.js;jsessionid=E58D035061346B05CE29B3F890F30681'\
-        \ ></script>\r\n<script>\r\n    require.config({\r\n        baseUrl: '/V2.0/js/realtimestats;jsessionid=E58D035061346B05CE29B3F890F30681'\r\
+        <script type=\"text/javascript\" src='/V2.0/js/realtimestats/libs/requirejs/require.js;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\
+        \ ></script>\r\n<script>\r\n    require.config({\r\n        baseUrl: '/V2.0/js/realtimestats;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429'\r\
         \n    });\r\n</script>\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\t\r\n\t<script>\r\
         \n\t\t$(function() {\r\n\t\t\t$('.tabs').tabs();\r\n\t\t\t$('input:submit').button();\r\
         \n\t\t\t$('.ui-icon').hover(\r\n\t\t\t\t\tfunction() { $(this).addClass('ui-state-hover');\
@@ -81,7 +81,7 @@ interactions:
         \n\t\tTo view the status of an existing ticket, visit the <a style=\"text-decoration:\
         \ underline\" href=\"http://support.dnsmadeeasy.com\">support site</a>.\r\n\
         \t</p>\r\n</div>\r\n\r\n<script>\r\n\r\n\tfunction showSubmitTicket() {\r\n\
-        \t\t$('#submitTicket').dialog('open');\r\n\t}\r\n\t\r\n\tajaxForm('/V2.0/support;jsessionid=E58D035061346B05CE29B3F890F30681',\
+        \t\t$('#submitTicket').dialog('open');\r\n\t}\r\n\t\r\n\tajaxForm('/V2.0/support;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429',\
         \ 'POST', '#submitTicketForm', '#submitTicketErrors', function(data, responseText,\
         \ jqXHR) {\r\n\t\t\r\n\t\t$('#dialog').dialog(\"destroy\");\r\n\t\t$(\"#dialog\"\
         )\r\n\t\t\t.html(\r\n\t\t\t\t'Your support request was successfully submitted.\
@@ -95,26 +95,26 @@ interactions:
         \ {resetForm:true});\r\n\t\t\t\t\t}\r\n\t\t\t\t});\r\n\r\n\t}, '#submitTicket',\
         \ {\r\n\t\twidth: 600,\r\n\t\tblock: true\r\n\t});\t\r\n\t\r\n</script>\r\n\
         <div style=\"width: 400px;margin: 0 auto;position: relative;top: 200px; text-align:\
-        \ center\">\r\n\t<a href=\"/console\">\r\n\t\t<img src=\"/V2.0/img/logo_dns.png;jsessionid=E58D035061346B05CE29B3F890F30681\"\
+        \ center\">\r\n\t<a href=\"/console\">\r\n\t\t<img src=\"/V2.0/img/logo_dns.png;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429\"\
         />\r\n\t</a>\r\n\t<h3>A system error has occurred.</h3>\r\n\t<p style=\"margin:\
         \ 3em auto\">\r\n\t\tHave no fear - our team of emergency response nerds have\
         \ already been alerted and are on the case.\r\n\t</p> \r\n\r\n\t<a href=\"\
-        /V2.0/;jsessionid=E58D035061346B05CE29B3F890F30681\">Return to console</a>\t\
+        /V2.0/;jsessionid=355ACD8ACF9F26FD792D6D017ABF8429\">Return to console</a>\t\
         <br class=\"clear\"/>\r\n\t\r\n\t\t<a id=\"submitTicketLink\" onclick=\"showSubmitTicket();\"\
         \ >Submit a support ticket</a>\r\n\t\r\n\t<a target=\"_blank\" href=\"http://support.dnsmadeeasy.com\"\
         >Support Center</a>\r\n\t<br class=\"clear\"/>\r\n\t<div style=\"margin-top:\
         \ 2em\">\r\n\t\t<small>Current IP address:   <br />\r\n\t\tLast logged in\
-        \ on Sun Mar 27 00:00:00 UTC 2016 from 208.72.142.184</small><br />\r\n\t\
+        \ on Sat Aug 27 00:00:00 UTC 2016 from 208.72.142.184</small><br />\r\n\t\
         </div>\r\n\t<div style=\"margin-top: 2em\">\r\n\t\t<small>Current Date and\
-        \ Time: 2016-03-30 01:58:58:108</small><br />\r\n\t</div>\r\n\t\r\n</div>\r\
+        \ Time: 2016-08-27 19:30:10:421</small><br />\r\n\t</div>\r\n\t\r\n</div>\r\
         \n\r\n</body>\r\n</html>"}
     headers:
       content-type: [text/html;charset=ISO-8859-1]
-      date: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:10 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=E58D035061346B05CE29B3F890F30681; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [58da9a2a-a1b5-418f-92ba-34757bc47633]
+      set-cookie: [JSESSIONID=355ACD8ACF9F26FD792D6D017ABF8429; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [7f3073f6-fb01-413d-ab0a-29437ea94315]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['148']
+      x-dnsme-requestsremaining: ['90']
     status: {code: 404, message: Not Found}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -8,42 +8,42 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:09 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459045687231,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:10 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=E4A583E7CA89B7D6BC7E00A0D1F4CF70; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [287af444-cf5c-4ed2-a1c3-73dde2034846]
+      set-cookie: [JSESSIONID=148280D74AF22AF1EB51D900F3E8965E; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [400e0751-2269-41f0-a98a-781ab7866f49]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['147']
+      x-dnsme-requestsremaining: ['89']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "A", "name": "localhost", "value": "127.0.0.1", "ttl": 86400}'
+    body: '{"type": "A", "name": "localhost", "value": "127.0.0.1", "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['70']
+      Content-Length: ['69']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:58:57 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:10 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"localhost","value":"127.0.0.1","id":10098820,"type":"A","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"localhost","value":"127.0.0.1","id":10124244,"type":"A","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:08 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098820']
+      date: ['Sat, 27 Aug 2016 19:30:10 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124244']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=F6F8E351946089BF3B76CE54B37E15CD; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a26f4f64-b852-4e10-a219-cfb958f2961d]
+      set-cookie: [JSESSIONID=687CFED66A4A05BE5FD1FAEE2CF29439; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [38f32e97-5f92-4510-ae97-366d07225b4b]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['146']
+      x-dnsme-requestsremaining: ['88']
     status: {code: 201, message: Created}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -8,42 +8,42 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:08 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:10 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:10 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:11 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=DFD44A796FCF1281A9E0DD55EDF4B15C; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [25bf437c-fa46-4428-b63f-46657089c45a]
+      set-cookie: [JSESSIONID=296137356CB165B0A522A612A3BA6190; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [7a1afead-4eba-4642-ba17-0fb53842745d]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['145']
+      x-dnsme-requestsremaining: ['87']
     status: {code: 200, message: OK}
 - request:
-    body: '{"type": "CNAME", "name": "docs", "value": "docs.example.com", "ttl": 86400}'
+    body: '{"type": "CNAME", "name": "docs", "value": "docs.example.com", "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['76']
+      Content-Length: ['75']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:09 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:11 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"docs","value":"docs.example.com","id":10098821,"type":"CNAME","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"docs","value":"docs.example.com","id":10124245,"type":"CNAME","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:10 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098821']
+      date: ['Sat, 27 Aug 2016 19:30:11 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124245']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=451CBC6026978077E1DEF5E93D6B2029; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [85b18ac9-a7f2-4d1e-907e-3823b67e531f]
+      set-cookie: [JSESSIONID=CBE4CAD84B6FD5E2189F158778238B54; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [11c5dedb-1fb9-4ff4-a452-ead89a22195f]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['144']
+      x-dnsme-requestsremaining: ['86']
     status: {code: 201, message: Created}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -8,43 +8,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:09 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:11 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:10 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:11 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=45D75F0518637E48C00DE740CDBCE4F7; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [7cdde412-57f3-487e-af59-97f04b71ab80]
+      set-cookie: [JSESSIONID=9BA6A62192EC106E4EADED59BBF3551E; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [0eb9b29f-e87c-4d47-b16c-82f7f787e50a]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['143']
+      x-dnsme-requestsremaining: ['85']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "_acme-challenge.fqdn", "value": "challengetoken",
-      "ttl": 86400}'
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['88']
+      Content-Length: ['87']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:10 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:11 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"_acme-challenge.fqdn","value":"\"challengetoken\"","id":10098822,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"_acme-challenge.fqdn","value":"\"challengetoken\"","id":10124246,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:11 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098822']
+      date: ['Sat, 27 Aug 2016 19:30:12 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124246']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=8FBD7AB8E2C54C72263815A55302351E; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [3f716f9f-d950-4203-9938-9fec9308d45d]
+      set-cookie: [JSESSIONID=262B1EEC9F86D42DE7F6760FDF6660C5; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [11d3b20b-b6a5-40ed-9fba-76920320b3a6]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['142']
+      x-dnsme-requestsremaining: ['84']
     status: {code: 201, message: Created}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -8,43 +8,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:10 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:12 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:11 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:12 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=5E62B1395498022D33133CE27ED7BB1E; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [f52991c1-8824-4551-a338-4d0388e511c0]
+      set-cookie: [JSESSIONID=DE002658DCAA318E7FFEAA971F12D4C5; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [c4f101ae-ebcf-451e-a63f-039e56dc01a3]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['141']
+      x-dnsme-requestsremaining: ['83']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "_acme-challenge.full", "value": "challengetoken",
-      "ttl": 86400}'
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['88']
+      Content-Length: ['87']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:10 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:12 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"_acme-challenge.full","value":"\"challengetoken\"","id":10098823,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"_acme-challenge.full","value":"\"challengetoken\"","id":10124247,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:11 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098823']
+      date: ['Sat, 27 Aug 2016 19:30:12 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124247']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=C10ED0462F6160DCF7255CE0D96286A8; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [fe1b5e48-5880-464c-b9ce-dabeb7b77ca5]
+      set-cookie: [JSESSIONID=D7CF212C6938EECD65635BF358D7AB8E; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [39d7c95e-022f-43e4-a5f6-389bf88cc89e]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['140']
+      x-dnsme-requestsremaining: ['82']
     status: {code: 201, message: Created}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -8,43 +8,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:11 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:13 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:11 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:14 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=B8582BE58EB020B7367D5145176C3BDD; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a9be8b3a-3148-437d-b637-12516fc7317f]
+      set-cookie: [JSESSIONID=CDC91B1FB7FAA8C83A42E96DD7BB3AE4; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [519d9499-2ea7-4cb3-943c-b3f5dd50cee9]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['139']
+      x-dnsme-requestsremaining: ['81']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "_acme-challenge.test", "value": "challengetoken",
-      "ttl": 86400}'
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['88']
+      Content-Length: ['87']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:11 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:13 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"_acme-challenge.test","value":"\"challengetoken\"","id":10098824,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"_acme-challenge.test","value":"\"challengetoken\"","id":10124248,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:12 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098824']
+      date: ['Sat, 27 Aug 2016 19:30:19 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124248']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=7C35AD9138DF9AD7E3E72439D867DDC9; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a1bf0ca8-07b9-421f-a7e8-44cf1cc70f7c]
+      set-cookie: [JSESSIONID=81692678A2804E12CFD10254FB49703C; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [88c67be7-6f5c-4014-b4f2-4bb302a639b6]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['138']
+      x-dnsme-requestsremaining: ['80']
     status: {code: 201, message: Created}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:12 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:19 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:12 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:19 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=3559C1807B6450D422F8C890C2CC2DE9; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [bacab8c7-afbe-4890-a9fb-7323fe7d35d1]
+      set-cookie: [JSESSIONID=A494D9CD804B7C82A3E5AED2BFA4C590; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [db6bd164-11dc-4105-acd8-277d5c7cf1f4]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['137']
+      x-dnsme-requestsremaining: ['79']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "delete.testfilt", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['83']
+      Content-Length: ['82']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:12 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:19 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"delete.testfilt","value":"\"challengetoken\"","id":10098825,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"delete.testfilt","value":"\"challengetoken\"","id":10124249,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:12 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098825']
+      date: ['Sat, 27 Aug 2016 19:30:19 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124249']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=885993796A767D1DFE345DBCD17057BD; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [c31b1f4f-0f34-40b9-8c0d-6423fd790511]
+      set-cookie: [JSESSIONID=45254FEE34364978FA7D9366F463B820; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [1f293b65-fa7d-4d6d-85eb-6cf69d90466d]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['136']
+      x-dnsme-requestsremaining: ['78']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,19 +56,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:12 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:20 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfilt&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"delete.testfilt","value":"\"challengetoken\"","id":10098825,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"delete.testfilt","value":"\"challengetoken\"","id":10124249,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:20 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=4CA70C061798789F47370D8A25EAEA05; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [f4e95403-80d1-457b-8234-2f4f80de84c0]
+      set-cookie: [JSESSIONID=E75548E37D1B143E52DD497D99D4200F; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [6d1960dc-a0ca-41b4-9df7-a8fa48e80e51]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['135']
+      x-dnsme-requestsremaining: ['77']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -79,20 +79,20 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:20 GMT']
     method: DELETE
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098825
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124249
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:20 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=E340B0F2EEC9FEE193301B75E612649F; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [388416b6-089a-42b1-a0f3-635787e658c5]
+      set-cookie: [JSESSIONID=B6E75116143A925A768838E0368CF908; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [8135900b-8654-4566-b7b9-f6a7d8f91ec0]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['134']
+      x-dnsme-requestsremaining: ['76']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -103,18 +103,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:20 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfilt&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[],"page":0,"totalRecords":0,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[],"page":0,"totalPages":1,"totalRecords":0}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:20 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=7EA9D642981E7A5F482F0ED7843CAA1E; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [1080e7eb-85b5-4242-a191-6373d7afb889]
+      set-cookie: [JSESSIONID=56D325A53BA5F7B059F45C5BF25E3CC4; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [6ecea453-74a9-4c36-a895-434db3483df9]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['133']
+      x-dnsme-requestsremaining: ['75']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:21 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:20 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=F85D4C991D1C9FB9A1EA7690135273FE; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [4c079722-77f7-41e4-a924-4a839586fd97]
+      set-cookie: [JSESSIONID=F4C218119784DC9FF5893E2D7BE04F93; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [26c2c195-7e95-4da7-8661-cac505ad95a5]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['132']
+      x-dnsme-requestsremaining: ['74']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "delete.testfqdn", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['83']
+      Content-Length: ['82']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:13 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:21 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"delete.testfqdn","value":"\"challengetoken\"","id":10098826,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"delete.testfqdn","value":"\"challengetoken\"","id":10124250,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:15 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098826']
+      date: ['Sat, 27 Aug 2016 19:30:22 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124250']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=EF5CEA59AC14E1566D535793F915B8CA; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [7129a4db-4412-44e6-ad91-b963e050393f]
+      set-cookie: [JSESSIONID=45B0E12F8FB12BE35628AF2231EC0222; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [08359078-4b1e-4809-9e22-4d6a18ae5411]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['131']
+      x-dnsme-requestsremaining: ['73']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,19 +56,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:14 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:21 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfqdn&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"delete.testfqdn","value":"\"challengetoken\"","id":10098826,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"delete.testfqdn","value":"\"challengetoken\"","id":10124250,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:22 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=9247C2B35F123E38EC3DB7E574BDBD4C; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [44db2c09-52b6-4d90-a69a-d08f641ca8a1]
+      set-cookie: [JSESSIONID=378928A7904E5A6BB1B8FBAD2CB8A2B0; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [9de7b645-befb-4227-9858-a0c979063233]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['130']
+      x-dnsme-requestsremaining: ['72']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -79,20 +79,20 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:14 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:21 GMT']
     method: DELETE
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098826
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124250
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:22 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=BBDA1C80AA4CD61F2556F978EF3B544B; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [8e13fb1e-89cd-496d-88b9-fc736f0dea5d]
+      set-cookie: [JSESSIONID=AC2FC3240D840076FD6597EF71FB0FB6; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [86411dea-6e70-4e4b-8849-5692cafd4b98]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['129']
+      x-dnsme-requestsremaining: ['71']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -103,18 +103,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:22 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfqdn&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[],"page":0,"totalRecords":0,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[],"page":0,"totalPages":1,"totalRecords":0}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:23 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=EA18066E7731DE219F927E7CC68DE57C; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [00f34379-b161-4e60-ad62-5dc9bf58b180]
+      set-cookie: [JSESSIONID=007E1921F5FFB11867A03B8002975FC1; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [da760e43-11a1-458b-9bab-831c0aa82334]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['128']
+      x-dnsme-requestsremaining: ['70']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:22 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:16 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:23 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=5D97E2D6C670CE17C5055D4B21B1F0A0; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [4a2db98d-61d2-424a-ab49-5f33dbaffa68]
+      set-cookie: [JSESSIONID=F4742E1C11EF023CB1E4E898D83FA556; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [d4bef642-4cfd-4872-9bf1-0adeaf20b1cf]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['127']
+      x-dnsme-requestsremaining: ['69']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "delete.testfull", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['83']
+      Content-Length: ['82']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:22 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"delete.testfull","value":"\"challengetoken\"","id":10098827,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"delete.testfull","value":"\"challengetoken\"","id":10124251,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:16 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098827']
+      date: ['Sat, 27 Aug 2016 19:30:23 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124251']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=6C97C9FC18D1D95826A0293C2792E9A0; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [3c9cedaa-ed93-4eb2-97e3-7092a2df5f94]
+      set-cookie: [JSESSIONID=5F952F7FFBBA29E5490EC7FFCF7B3463; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [f1d7eb42-b8ee-4a68-9eb8-24d66bd8f66c]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['126']
+      x-dnsme-requestsremaining: ['68']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,19 +56,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:15 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:23 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfull&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"delete.testfull","value":"\"challengetoken\"","id":10098827,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"delete.testfull","value":"\"challengetoken\"","id":10124251,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:16 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:24 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=F87EED3199BAEA7F8718A645112014EB; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [ace70428-a112-45b6-801b-416e7f237e53]
+      set-cookie: [JSESSIONID=DB7E1F4E3318491E022053249C1A24E7; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [f0c522f3-2b2a-4fc7-91b6-92ec3679b1af]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['125']
+      x-dnsme-requestsremaining: ['67']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -79,20 +79,20 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:16 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:23 GMT']
     method: DELETE
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098827
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124251
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:24 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=3C1490A35DB32D837F8CA8BB1520D9D8; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [c38c5950-6575-4f1f-be89-ec473e792733]
+      set-cookie: [JSESSIONID=93C656F16EE076B45EAECD74DBEA8588; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [0162871b-faf7-4207-baa4-04803ab69a81]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['124']
+      x-dnsme-requestsremaining: ['66']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -103,18 +103,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:16 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:24 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testfull&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[],"page":0,"totalRecords":0,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[],"page":0,"totalPages":1,"totalRecords":0}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:24 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=4A7B7FF4A082F4DDA02656E520540EB3; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [8b88f14a-544c-4cd9-a2b5-03bd70a91347]
+      set-cookie: [JSESSIONID=D0FEADEB1E932E62570DC6AFEEE90BF6; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [ddd7e8cc-e28d-4965-8d11-4fd86cb80322]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['123']
+      x-dnsme-requestsremaining: ['65']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:16 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:24 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:25 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=B7DADF4A7BB2041F309A46D8BECA3F1B; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [fa729fd5-4585-4060-8b35-7dfe50897de6]
+      set-cookie: [JSESSIONID=C75AFDE3C9C274DCD416D57C067294FD; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [e9bd13df-5409-426b-82bc-0ac7e1a9424a]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['122']
+      x-dnsme-requestsremaining: ['64']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "delete.testid", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['81']
+      Content-Length: ['80']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:24 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"delete.testid","value":"\"challengetoken\"","id":10098828,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"delete.testid","value":"\"challengetoken\"","id":10124252,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:17 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098828']
+      date: ['Sat, 27 Aug 2016 19:30:25 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124252']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=D22EC687ACD21DCBBFE831B422691128; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [1c040159-b0bc-4ef8-b734-c5f414d7ab4a]
+      set-cookie: [JSESSIONID=C42A8F9A803A4191E105EDB1E938E17F; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [5557731e-f739-4d53-859b-fe50391d79fd]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['121']
+      x-dnsme-requestsremaining: ['63']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,19 +56,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:25 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testid&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"delete.testid","value":"\"challengetoken\"","id":10098828,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"delete.testid","value":"\"challengetoken\"","id":10124252,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:25 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=13A0AF2B712EEAFB46143088E74EE6A0; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [d3123aca-b783-45e9-9a6f-cb0ea80344af]
+      set-cookie: [JSESSIONID=73067848D7EA15E4046320A1A5042E78; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [1f8a30bf-d65e-4a6c-bf6e-70fa36fe5f46]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['120']
+      x-dnsme-requestsremaining: ['62']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -79,20 +79,20 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:17 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:25 GMT']
     method: DELETE
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098828
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124252
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:26 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=23E3B9DAEF9414443FDE0D0C55281944; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [234d25b7-710b-4703-967e-2d83294c0d5c]
+      set-cookie: [JSESSIONID=55A1B8BE396D8661ECD525F768E2B13A; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [268779ba-15be-428d-a76c-36d42a5781d7]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['119']
+      x-dnsme-requestsremaining: ['61']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -103,18 +103,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:26 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=delete.testid&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[],"page":0,"totalRecords":0,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[],"page":0,"totalPages":1,"totalRecords":0}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:26 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=EB36DB7754934DD5F15294FEA3B9D10B; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a818bbc6-dedd-4693-94cd-b2227823f8ea]
+      set-cookie: [JSESSIONID=78F6EA456B68D7417CB6B9455A7AF4A9; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [297dd579-f1ea-4e13-a8d0-b84ed1843908]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['118']
+      x-dnsme-requestsremaining: ['60']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -8,19 +8,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:17:56 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:26 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1469912667781}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Sat, 30 Jul 2016 21:17:57 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:26 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=C3E1EC43F205291DE2EFCEC754AE1C9B; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [da2c0e9b-acfe-41ad-9bdc-fde691cd05a2]
+      set-cookie: [JSESSIONID=991B724137B73C14FAD494757D99E5A4; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [7887fb2a-af13-4b97-b76b-053114585c9b]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['149']
+      x-dnsme-requestsremaining: ['59']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "ttl.fqdn", "value": "ttlshouldbe3600", "ttl":
@@ -32,20 +32,20 @@ interactions:
       Content-Length: ['76']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:17:57 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:26 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10123501,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
+    body: {string: !!python/unicode '{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10124253,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Sat, 30 Jul 2016 21:18:03 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10123501']
+      date: ['Sat, 27 Aug 2016 19:30:27 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124253']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=5F6B2969090A00FE4785EF306D0FB721; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [cc0f497c-2e88-4e8a-852f-78a4320aefae]
+      set-cookie: [JSESSIONID=C811061400BC9ECF9C976270843C3062; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [54b89fd6-ef84-45ef-92b5-7d96e7735087]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['148']
+      x-dnsme-requestsremaining: ['58']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,18 +56,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Sat, 30 Jul 2016 21:18:02 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:27 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=ttl.fqdn&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10123501,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10124253,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Sat, 30 Jul 2016 21:18:03 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:27 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=A4E269008AB4A100D6747658D5B1EED6; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [3c968cd1-fc2a-466a-940d-de689c423751]
+      set-cookie: [JSESSIONID=136910DE5BEE0DBF13777F8FF7D0CD0C; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [e8bea938-f0da-46d7-83bf-57b2aa17f94c]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['147']
+      x-dnsme-requestsremaining: ['57']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:27 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:27 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=43AB9AA7587F3363BC24C78553767FA4; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [39a92c3f-802d-496d-be33-07a2bf0d2575]
+      set-cookie: [JSESSIONID=2CCB0E75D93C448E0FB180EC48F15A13; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [2297efdc-c459-45fe-851f-ae29ef154429]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['117']
+      x-dnsme-requestsremaining: ['56']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "random.fqdntest", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['83']
+      Content-Length: ['82']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:18 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:27 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"random.fqdntest","value":"\"challengetoken\"","id":10098829,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"random.fqdntest","value":"\"challengetoken\"","id":10124254,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:19 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098829']
+      date: ['Sat, 27 Aug 2016 19:30:28 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124254']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=A75AE93B1EBD7AB2FAE2803BAF32EBF8; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [ca0d020b-5e3d-4ee4-a5e5-d5fb2f6770c3]
+      set-cookie: [JSESSIONID=0AB2E475ED40541D33D6F718486157B3; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [0b66a1e3-883d-437d-a72f-66227d02fe26]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['116']
+      x-dnsme-requestsremaining: ['55']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,18 +56,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:28 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=random.fqdntest&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"random.fqdntest","value":"\"challengetoken\"","id":10098829,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"random.fqdntest","value":"\"challengetoken\"","id":10124254,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:28 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=414B204D12F9CFB817E9EA72A2273260; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [8f703615-3f06-4c04-9d48-1ac79228ef42]
+      set-cookie: [JSESSIONID=562621EC3CACEA07F6ADDAD98D92B905; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [09e358cb-36a4-4c39-87f5-40c5577f9999]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['115']
+      x-dnsme-requestsremaining: ['54']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:28 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:28 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=F37EF3B88646978B3B203FBF2B49393F; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [95c27a18-d9a4-4ed2-84c5-98a358f49718]
+      set-cookie: [JSESSIONID=835BAEE878497CD294C02085D6B5C49C; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [8ed99699-45a4-44dc-a800-2f59d3b2ee95]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['114']
+      x-dnsme-requestsremaining: ['53']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "random.fulltest", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['83']
+      Content-Length: ['82']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:19 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:28 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"random.fulltest","value":"\"challengetoken\"","id":10098830,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"random.fulltest","value":"\"challengetoken\"","id":10124255,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:21 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098830']
+      date: ['Sat, 27 Aug 2016 19:30:28 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124255']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=09D4ADE9FD670881A8F2427EA7574DE7; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a9fded1e-1b19-4b63-9569-a250c2cce933]
+      set-cookie: [JSESSIONID=43F74E53103C9D4D5D1EE28DDBBF4285; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [ccf76b80-709d-4322-ba3c-377092a20bbb]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['113']
+      x-dnsme-requestsremaining: ['52']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,18 +56,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:20 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:29 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=random.fulltest&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"random.fulltest","value":"\"challengetoken\"","id":10098830,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"random.fulltest","value":"\"challengetoken\"","id":10124255,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:21 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:30 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=557007B97212EA23FD3D4C4AF51E0308; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [ad522aaf-ab54-4526-98ad-05e6fdf7d366]
+      set-cookie: [JSESSIONID=6462C1447A65005C2CFB1EEA37CDD89C; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [df27f470-8d77-4d6b-9cd2-de33c706658a]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['112']
+      x-dnsme-requestsremaining: ['51']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:20 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:29 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:21 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:30 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=EB3E82C0319C637874B8031FCFF92657; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [e93a4867-8617-40cb-bb7e-cb0b07f9c55f]
+      set-cookie: [JSESSIONID=B199026B5F09298992D4C38ECF7581CA; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [359a626a-1746-4826-b03f-6f4110c633e9]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['111']
+      x-dnsme-requestsremaining: ['50']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "random.test", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['79']
+      Content-Length: ['78']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:20 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:29 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"random.test","value":"\"challengetoken\"","id":10098831,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"random.test","value":"\"challengetoken\"","id":10124256,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:21 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098831']
+      date: ['Sat, 27 Aug 2016 19:30:30 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124256']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=5390FED975B218A8E270DA5759C445E1; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [421ac122-162b-4db0-964f-baae20adbdbd]
+      set-cookie: [JSESSIONID=D74C54E837B4E4867DA68C635E557CCF; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [11cecaa0-d52e-4513-92f9-11d20044d2f1]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['110']
+      x-dnsme-requestsremaining: ['49']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,18 +56,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:21 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:30 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=random.test&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"random.test","value":"\"challengetoken\"","id":10098831,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"random.test","value":"\"challengetoken\"","id":10124256,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:22 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:30 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=0E9AF4E9BFA08A05F42839B72E823DDC; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [f6aaa0a6-4035-4c2b-8f11-bb990c166d04]
+      set-cookie: [JSESSIONID=C5E35C64CF02301C9F88BE776616943D; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [b54fa499-2f29-49b4-8253-91fe8d58ab5e]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['109']
+      x-dnsme-requestsremaining: ['48']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -8,19 +8,19 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:21 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:30 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:22 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:31 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=BB01A71C13D4C90D855BA74B01E5A867; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [1b4889a7-4862-40b8-9b27-d5de8bbc8489]
+      set-cookie: [JSESSIONID=6DE027ECB9AC13E88153A20448A7953D; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [e3de1aa5-185d-4db0-aa0b-4775aa5be7b5]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['108']
+      x-dnsme-requestsremaining: ['47']
     status: {code: 200, message: OK}
 - request:
     body: '{}'
@@ -31,18 +31,18 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:21 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:30 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"_acme-challenge.fqdn","value":"\"challengetoken\"","id":10098822,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"_acme-challenge.full","value":"\"challengetoken\"","id":10098823,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"_acme-challenge.test","value":"\"challengetoken\"","id":10098824,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"docs","value":"docs.example.com","id":10098821,"type":"CNAME","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"localhost","value":"127.0.0.1","id":10098820,"type":"A","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"random.fqdntest","value":"\"challengetoken\"","id":10098829,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"random.fulltest","value":"\"challengetoken\"","id":10098830,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"random.test","value":"\"challengetoken\"","id":10098831,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984},{"name":"updated.test","value":"\"challengetoken\"","id":10098508,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":9,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"_acme-challenge.fqdn","value":"\"challengetoken\"","id":10124246,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"_acme-challenge.full","value":"\"challengetoken\"","id":10124247,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"_acme-challenge.test","value":"\"challengetoken\"","id":10124248,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"docs","value":"docs.example.com","id":10124245,"type":"CNAME","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"localhost","value":"127.0.0.1","id":10124244,"type":"A","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"random.fqdntest","value":"\"challengetoken\"","id":10124254,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"random.fulltest","value":"\"challengetoken\"","id":10124255,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"random.test","value":"\"challengetoken\"","id":10124256,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false},{"name":"ttl.fqdn","value":"\"ttlshouldbe3600\"","id":10124253,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":9}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:22 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:31 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=D8D6049A8986D6140518ABE406BDF3E5; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [039cb598-e894-48d3-ac87-dd0f38a5d363]
+      set-cookie: [JSESSIONID=6D96BF1705BB0A0A3F4DEB5782425264; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [d0bddde5-69e5-4903-a4aa-20e0c510a0e2]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['107']
+      x-dnsme-requestsremaining: ['46']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 02:05:23 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:30 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303477998,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 02:05:24 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:31 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=912EF4016E92632D617817F4238B32E9; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [8d26170b-5841-4be1-a898-445e4795ea45]
+      set-cookie: [JSESSIONID=90E55821E898B39151B36C86A5D1E0BD; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [e695d9b1-21c1-4538-ba0c-a0aa0d5b5802]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['148']
+      x-dnsme-requestsremaining: ['45']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "orig.test", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['77']
+      Content-Length: ['76']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 02:05:23 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:30 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"orig.test","value":"\"challengetoken\"","id":10098835,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"orig.test","value":"\"challengetoken\"","id":10124257,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 02:05:24 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098835']
+      date: ['Sat, 27 Aug 2016 19:30:34 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124257']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=8C34F2FB5E03E243F8E5B6DBDC9CA32F; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [0183a8a6-58a2-4a77-a213-dd0cf1d08b68]
+      set-cookie: [JSESSIONID=E6ABDF0EBDAD87246C5C108466087428; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [10bc971a-eb5b-4907-94c2-8f4b5d7ba301]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['147']
+      x-dnsme-requestsremaining: ['44']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,43 +56,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 02:05:24 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:34 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=orig.test&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"orig.test","value":"\"challengetoken\"","id":10098835,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"orig.test","value":"\"challengetoken\"","id":10124257,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 02:05:24 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:34 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=AFA086F1FC300221535F0BE43B540F43; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [79672e2b-6f7a-43de-b3c9-d2f250e29b51]
+      set-cookie: [JSESSIONID=EBF66BA8D5E98E38A385642B530394BC; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [30373908-bc51-4bcf-bf7e-9c188fbfde83]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['146']
+      x-dnsme-requestsremaining: ['43']
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "challengetoken", "type": "TXT", "id": 10098835, "name": "updated.test",
-      "ttl": 86400}'
+    body: '{"value": "challengetoken", "type": "TXT", "id": 10124257, "name": "updated.test",
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['96']
+      Content-Length: ['95']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 02:05:24 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:34 GMT']
     method: PUT
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098835
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124257
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 02:05:25 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:34 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=6AD9C5590D477AD7F5B99CC607BF960C; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [1b61a856-84b2-4541-925e-878656fcd3ee]
+      set-cookie: [JSESSIONID=1986EB225F8506910B43B3060F4AE5E0; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [a87e5414-12af-425d-9f1f-1604869d95fb]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['145']
+      x-dnsme-requestsremaining: ['42']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:22 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:35 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:23 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:34 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=8A5353017277CBE177FCAEDE3E3DBD66; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [f013e91b-06aa-4a65-80fc-47abc17f3cd7]
+      set-cookie: [JSESSIONID=E0999345AFB61F223C0EF4E12F703497; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [bfa09aeb-d3a0-4129-a1eb-115aa00bee7c]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['102']
+      x-dnsme-requestsremaining: ['41']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "orig.testfqdn", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['81']
+      Content-Length: ['80']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:22 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:35 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"orig.testfqdn","value":"\"challengetoken\"","id":10098833,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"orig.testfqdn","value":"\"challengetoken\"","id":10124258,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:24 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098833']
+      date: ['Sat, 27 Aug 2016 19:30:36 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124258']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=7BA374A000CE46852B69725CA5FDDB02; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [2590a164-dd37-4c4c-b10a-6817e4e57153]
+      set-cookie: [JSESSIONID=2146B2E71E8DDBE0838A9C64BB96FF6E; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [bb6d1a07-fb79-45d6-befd-400ab9fd3c94]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['101']
+      x-dnsme-requestsremaining: ['40']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,43 +56,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:23 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:35 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=orig.testfqdn&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"orig.testfqdn","value":"\"challengetoken\"","id":10098833,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"orig.testfqdn","value":"\"challengetoken\"","id":10124258,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:36 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=860265F5A5817FE8928FA0F45D887ADA; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [6430aa90-b768-483f-96ab-ad7e9a3140e7]
+      set-cookie: [JSESSIONID=FA0257E71C317985500CEF78040CC693; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [da173404-defe-4843-bb87-21c4122024ba]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['100']
+      x-dnsme-requestsremaining: ['39']
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "challengetoken", "type": "TXT", "id": 10098833, "name": "updated.testfqdn",
-      "ttl": 86400}'
+    body: '{"value": "challengetoken", "type": "TXT", "id": 10124258, "name": "updated.testfqdn",
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['100']
+      Content-Length: ['99']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:23 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:35 GMT']
     method: PUT
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098833
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124258
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:36 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=1C3BE2E3A9251C34E8234F469E275EA7; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [5685b009-3f8d-4c65-afbb-0bdf31dce8c0]
+      set-cookie: [JSESSIONID=FFD0C388882D6036FF7476E0A8E2B848; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [782e20a0-d37d-4bae-8856-e730b04c4318]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['99']
+      x-dnsme-requestsremaining: ['38']
     status: {code: 200, message: OK}
 version: 1

--- a/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dnsmadeeasy/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -8,44 +8,44 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:36 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/name?domainname=capsulecd.com
   response:
-    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"nameServers":[{"fqdn":"ns0.dnsmadeeasy.com","ipv4":"208.94.148.2","ipv6":"2600:1800:0::1"},{"fqdn":"ns1.dnsmadeeasy.com","ipv4":"208.80.124.2","ipv6":"2600:1801:1::1"},{"fqdn":"ns2.dnsmadeeasy.com","ipv4":"208.80.126.2","ipv6":"2600:1802:2::1"},{"fqdn":"ns3.dnsmadeeasy.com","ipv4":"208.80.125.2","ipv6":"2600:1801:3::1"},{"fqdn":"ns4.dnsmadeeasy.com","ipv4":"208.80.127.2","ipv6":"2600:1802:4::1"}],"pendingActionId":0,"updated":1459303138386,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false}'}
+    body: {string: !!python/unicode '{"name":"capsulecd.com","id":874984,"created":1458864000000,"processMulti":false,"activeThirdParties":[],"delegateNameServers":["dawn.ns.cloudflare.com.","owen.ns.cloudflare.com."],"folderId":1668,"gtdEnabled":false,"nameServers":[{"ipv4":"208.94.147.112","ipv6":"2600:1800:0::1","fqdn":"ns1.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.113","ipv6":"2600:1801:1::1","fqdn":"ns2.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.114","ipv6":"2600:1802:2::1","fqdn":"ns3.sandbox.dnsmadeeasy.com"},{"ipv4":"208.94.147.116","ipv6":"2600:1801:3::1","fqdn":"ns4.sandbox.dnsmadeeasy.com"}],"pendingActionId":0,"updated":1472326176934}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:37 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=F71372AAF5211B98859432701D9E3183; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [a7861e6d-9a52-4f99-953c-ac54a3a50ecb]
+      set-cookie: [JSESSIONID=9114D6B1912BADF0ACA504EC3F00779E; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [e777c3f4-addc-4593-987a-890563ba6e13]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['98']
+      x-dnsme-requestsremaining: ['37']
     status: {code: 200, message: OK}
 - request:
     body: '{"type": "TXT", "name": "orig.testfull", "value": "challengetoken", "ttl":
-      86400}'
+      3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['81']
+      Content-Length: ['80']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:36 GMT']
     method: POST
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/
   response:
-    body: {string: !!python/unicode '{"name":"orig.testfull","value":"\"challengetoken\"","id":10098834,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}'}
+    body: {string: !!python/unicode '{"name":"orig.testfull","value":"\"challengetoken\"","id":10124259,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:25 GMT']
-      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098834']
+      date: ['Sat, 27 Aug 2016 19:30:37 GMT']
+      location: ['http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124259']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=D69630E8F686092EB37FB86C74A5EB8C; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [4a39cda8-70cf-4d09-82b1-22e53c8034c3]
+      set-cookie: [JSESSIONID=E93504E98E304A6FE57306D587A35C10; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [f889340f-7b23-4f41-b336-82e00c912a6a]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['97']
+      x-dnsme-requestsremaining: ['36']
     status: {code: 201, message: Created}
 - request:
     body: '{}'
@@ -56,43 +56,43 @@ interactions:
       Content-Length: ['2']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:24 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:37 GMT']
     method: GET
     uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records?recordName=orig.testfull&type=TXT
   response:
-    body: {string: !!python/unicode '{"data":[{"name":"orig.testfull","value":"\"challengetoken\"","id":10098834,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":86400,"failover":false,"monitor":false,"sourceId":874984}],"page":0,"totalRecords":1,"totalPages":1}'}
+    body: {string: !!python/unicode '{"data":[{"name":"orig.testfull","value":"\"challengetoken\"","id":10124259,"type":"TXT","source":1,"dynamicDns":false,"failed":false,"gtdLocation":"DEFAULT","hardLink":false,"ttl":3600,"monitor":false,"sourceId":874984,"failover":false}],"page":0,"totalPages":1,"totalRecords":1}'}
     headers:
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:25 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:37 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=E2093218F6A3FCBB62959775103EDECF; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [c7c46780-2d4e-42bb-a983-ffcc5c3f45c3]
+      set-cookie: [JSESSIONID=55695A2C29B0A3799634DD6FA39AAD0C; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [9e79645f-0be0-4c61-92d3-a3a1e9e4d339]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['96']
+      x-dnsme-requestsremaining: ['35']
     status: {code: 200, message: OK}
 - request:
-    body: '{"value": "challengetoken", "type": "TXT", "id": 10098834, "name": "updated.testfull",
-      "ttl": 86400}'
+    body: '{"value": "challengetoken", "type": "TXT", "id": 10124259, "name": "updated.testfull",
+      "ttl": 3600}'
     headers:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['100']
+      Content-Length: ['99']
       Content-Type: [application/json]
       User-Agent: [python-requests/2.9.1]
-      x-dnsme-requestDate: ['Wed, 30 Mar 2016 01:59:25 GMT']
+      x-dnsme-requestDate: ['Sat, 27 Aug 2016 19:30:37 GMT']
     method: PUT
-    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10098834
+    uri: http://api.sandbox.dnsmadeeasy.com/V2.0/dns/managed/874984/records/10124259
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
       content-type: [application/json]
-      date: ['Wed, 30 Mar 2016 01:59:25 GMT']
+      date: ['Sat, 27 Aug 2016 19:30:38 GMT']
       server: [Apache-Coyote/1.1]
-      set-cookie: [JSESSIONID=755A8295A256C96C2F82C0AB22A94BEE; Path=/V2.0/; HttpOnly]
-      x-dnsme-requestid: [dac87b11-de51-4c05-b3a7-83d4464c724c]
+      set-cookie: [JSESSIONID=AFB9249D585674DB8060A5BB6A8F76C8; Path=/V2.0/; HttpOnly]
+      x-dnsme-requestid: [7ac7006b-f693-4200-a8f4-5dc4d27b006e]
       x-dnsme-requestlimit: ['150']
-      x-dnsme-requestsremaining: ['95']
+      x-dnsme-requestsremaining: ['34']
     status: {code: 200, message: OK}
 version: 1


### PR DESCRIPTION
… tests.

closes #52 
I wiped out the integration test recordings for dnsmadeeasy and re-ran them using the default ttl of 3600 without any issues. I'm not sure why @unclespeedo ran into his issue. 