### PR TITLE
DreamHost API stub

### DIFF
--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -32,7 +32,11 @@ def MainParser():
     providers = sorted(providers)
 
     parser = argparse.ArgumentParser(description='Create, Update, Delete, List DNS entries')
-    parser.add_argument('--version', help="show the current version of lexicon", action='version', version='%(prog)s {0}'.format(pkg_resources.get_distribution("dns-lexicon").version))
+    try:
+        version = pkg_resources.get_distribution("dns-lexicon").version
+    except pkg_resources.DistributionNotFound:
+        version = 'unknown'
+    parser.add_argument('--version', help="show the current version of lexicon", action='version', version='%(prog)s {0}'.format(version))
     subparsers = parser.add_subparsers(dest='provider_name', help='specify the DNS provider to use')
 
     for provider in providers:

--- a/lexicon/providers/dreamhost.py
+++ b/lexicon/providers/dreamhost.py
@@ -1,0 +1,44 @@
+
+from base import Provider as BaseProvider
+
+from dreamhostapi import DreamHostAPI
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-token", help="specify token used authenticate")
+
+class Provider(BaseProvider):
+
+    def __init__(self, options, provider_options={}):
+        super(Provider, self).__init__(options)
+        self.api = None
+
+    # Authenicate against provider,
+    # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
+    # Should throw an error if authentication fails for any reason, of if the domain does not exist.
+    def authenticate(self):
+        self.api = DreamHostAPI(self.options['auth_token'])
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+	dhrecords = self.api.dns.list_records()
+        records = []
+        for record in dhrecords:
+            remapped = {
+                'type': record['type'],
+                'name': record['record'],
+                'content': record['value'],
+            }
+            records.append(remapped)
+
+        if type:
+            records = [record for record in records if record['type'] == type]
+        if name:
+            records = [record for record in records if record['name'] == name]
+        if content:
+            records = [record for record in records if record['content'] == content]
+
+        print 'list_records: {0}'.format(records)
+        return records

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests[security]
 tldextract
+dreamhostapi


### PR DESCRIPTION
This allows to list domain for DreamHost API (#56). Current output is a list of records like `{'content': u'64.90.40.29', 'type': u'A', 'name': u'www.ruby.rainforce.org'},`
