### PR TITLE
Fix default ttl settings for dnsmadeeasy

### DIFF
--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -34,7 +34,7 @@ class Provider(BaseProvider):
             'type': type,
             'name': self._relative_name(name),
             'value': content,
-            'ttl': self.options.get('ttl',self.default_ttl)
+            'ttl': self.options.get('ttl') or self.default_ttl
         }
         payload = {}
         try:
@@ -79,7 +79,7 @@ class Provider(BaseProvider):
 
         data = {
             'id': identifier,
-            'ttl': self.options.get('ttl',self.default_ttl)
+            'ttl': self.options.get('ttl') or self.default_ttl
         }
 
         if name:


### PR DESCRIPTION
The code to use the default ttl didn't work, it would result in a value of "none" instead of 3600.  This change needs to be made elsewhere also.
Signed Off: Josh Stompro <github@stompro.org>