### PR TITLE
Add functionality for handling delegated subdomains

### DIFF
--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -35,6 +35,7 @@ def MainParser():
 
     parser = argparse.ArgumentParser(description='Create, Update, Delete, List DNS entries')
     parser.add_argument('--version', help="show the current version of lexicon", action='version', version='%(prog)s {0}'.format(pkg_resources.get_distribution("dns-lexicon").version))
+    parser.add_argument('--delegated', help="specify the delegated domain")
     subparsers = parser.add_subparsers(dest='provider_name', help='specify the DNS provider to use')
     subparsers.required = True
 

--- a/lexicon/client.py
+++ b/lexicon/client.py
@@ -12,6 +12,16 @@ class Client(object):
         domain_parts = tldextract.extract(options.get('domain'))
         options['domain'] = '{0}.{1}'.format(domain_parts.domain, domain_parts.suffix)
 
+        if options.get('delegated'):
+            # handle delegated domain
+            delegated = options.get('delegated').rstrip('.')
+            # convert to relative name
+            if delegated.endswith(options.get('domain')):
+                delegated = delegated[:-len(options.get('domain'))]
+                delegated = delegated.rstrip('.')
+            # update domain
+            options['domain'] = '{0}.{1}'.format(delegated, options.get('domain'))
+
         self.action = options.get('action')
         self.provider_name = options.get('provider_name')
         self.options = options

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,6 +29,36 @@ def test_Client_init_when_domain_includes_subdomain_should_strip():
     assert client.options['domain'] == 'example.com'
     assert client.options['type'] == options['type']
 
+def test_Client_init_with_delegated_domain_name():
+    options = {
+        'provider_name':'base',
+        'action': 'list',
+        'domain': 'example.com',
+        'delegated': 'sub',
+        'type': 'TXT'
+    }
+    client = lexicon.client.Client(options)
+
+    assert client.provider_name == options['provider_name']
+    assert client.action == options['action']
+    assert client.options['domain'] == "sub.example.com"
+    assert client.options['type'] == options['type']
+
+def test_Client_init_with_delegated_domain_fqdn():
+    options = {
+        'provider_name':'base',
+        'action': 'list',
+        'domain': 'example.com',
+        'delegated': 'sub.example.com',
+        'type': 'TXT'
+    }
+    client = lexicon.client.Client(options)
+
+    assert client.provider_name == options['provider_name']
+    assert client.action == options['action']
+    assert client.options['domain'] == "sub.example.com"
+    assert client.options['type'] == options['type']
+
 
 def test_Client_init_when_missing_provider_should_fail():
     options = {


### PR DESCRIPTION
New `--delegated DELEGATED` option for specifying delegated domain.

Tested with NS1 and Python 2.7.13, but don't see any reason it wouldn't work with everything else. 