### PR TITLE
Run without installing

### DIFF
--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -34,7 +34,11 @@ def MainParser():
     providers = sorted(providers)
 
     parser = argparse.ArgumentParser(description='Create, Update, Delete, List DNS entries')
-    parser.add_argument('--version', help="show the current version of lexicon", action='version', version='%(prog)s {0}'.format(pkg_resources.get_distribution("dns-lexicon").version))
+    try:
+        version = pkg_resources.get_distribution("dns-lexicon").version
+    except pkg_resources.DistributionNotFound:
+        version = 'unknown'
+    parser.add_argument('--version', help="show the current version of lexicon", action='version', version='%(prog)s {0}'.format(version))
     parser.add_argument('--delegated', help="specify the delegated domain")
     subparsers = parser.add_subparsers(dest='provider_name', help='specify the DNS provider to use')
     subparsers.required = True


### PR DESCRIPTION
`lexicon` fails to run if executed from repository. This PR fixes that.
```
>python -m lexicon
...
pkg_resources.DistributionNotFound: The 'dns-lexicon' distribution was not found and is required by the application
```