### PR TITLE
Initial implementation of a provider for PowerDNS

### DIFF
--- a/lexicon/providers/powerdns.py
+++ b/lexicon/providers/powerdns.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from .base import Provider as BaseProvider
 import requests
 import json
-import os
 
 # Lexicon PowerDNS Provider
 #
@@ -39,8 +38,6 @@ class Provider(BaseProvider):
         super(Provider, self).__init__(options)
 
         self.api_endpoint = options.get('pdns_server')
-        if self.api_endpoint is None:
-            self.api_endpoint = os.environ.get("LEXICON_POWERDNS_PDNS_SERVER")
 
         if self.api_endpoint.endswith('/'):
             self.api_endpoint = self.api_endpoint[:-1]

--- a/lexicon/providers/powerdns.py
+++ b/lexicon/providers/powerdns.py
@@ -1,0 +1,204 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from .base import Provider as BaseProvider
+import requests
+import json
+import os
+
+# Lexicon PowerDNS Provider
+#
+# Author: Will Hughes, 2017
+#
+# API Docs: https://doc.powerdns.com/md/httpapi/api_spec/
+#
+# Implementation notes:
+# * The PowerDNS API does not assign a unique identifier to each record in the way
+#   that Lexicon expects. We work around this by creating an ID based on the record
+#   name, type and content, which when taken together are always unique
+# * The PowerDNS API has no notion of 'create a single record' or 'delete a single
+#   record'. All operations are either 'replace the RRSet with this new set of records'
+#   or 'delete all records for this name and type. Similarly, there is no notion of
+#   'change the content of this record', because records are identified by their name,
+#   type and content.
+# * The API is very picky about the format of values used when creating records:
+# ** CNAMEs must be fully qualified
+# ** TXT, LOC records must be quoted
+#   This is why the _clean_content and _unclean_content methods exist, to convert
+#   back and forth between the format PowerDNS expects, and the format Lexicon uses
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-token", help="specify token used authenticate")
+    subparser.add_argument("--pdns-server", help="URI for PowerDNS server")
+    subparser.add_argument("--pdns-server-id", help="Server ID to interact with")
+
+
+class Provider(BaseProvider):
+
+    def __init__(self, options, provider_options={}):
+        super(Provider, self).__init__(options)
+
+        self.api_endpoint = options.get('pdns_server')
+        if self.api_endpoint is None:
+            self.api_endpoint = os.environ.get("LEXICON_POWERDNS_PDNS_SERVER")
+
+        if self.api_endpoint.endswith('/'):
+            self.api_endpoint = self.api_endpoint[:-1]
+
+        if not self.api_endpoint.endswith("/api/v1"):
+            self.api_endpoint += "/api/v1"
+
+        self.server_id = options.get('pdns_server_id')
+        if self.server_id is None:
+            self.server_id = 'localhost'
+
+        self.api_endpoint += "/servers/" + self.server_id
+
+        self.api_key = self.options.get('auth_token')
+        assert self.api_key is not None
+
+        self._zone_data = None
+
+    def zone_data(self):
+        if self._zone_data is None:
+            self._zone_data = self._get('/zones/' + self.options['domain']).json()
+        return self._zone_data
+
+    def authenticate(self):
+        self.zone_data()
+        self.domain_id = self.options['domain']
+
+    def _make_identifier(self, type, name, content):
+        return "{}/{}={}".format(type, name, content)
+
+    def _parse_identifier(self, identifier):
+        parts = identifier.split('/')
+        type = parts[0]
+        parts = parts[1].split('=')
+        name = parts[0]
+        content = "=".join(parts[1:])
+        return type, name, content
+
+    def list_records(self, type=None, name=None, content=None):
+        records = []
+        for rrset in self.zone_data()['rrsets']:
+            if (name is None or self._fqdn_name(rrset['name']) == self._fqdn_name(name)) and (type is None or rrset['type'] == type):
+                for record in rrset['records']:
+                    if content is None or record['content'] == self._clean_content(type, content):
+                        records.append({
+                            'type': rrset['type'],
+                            'name': self._full_name(rrset['name']),
+                            'ttl': rrset['ttl'],
+                            'content': self._unclean_content(rrset['type'], record['content']),
+                            'id': self._make_identifier(rrset['type'], rrset['name'], record['content'])
+                        })
+        print('list_records: {0}'.format(records))
+        return records
+
+    def _clean_content(self, type, content):
+        if type in ("TXT", "LOC"):
+            if content[0] != '"':
+                content = '"' + content
+            if content[-1] != '"':
+                content += '"'
+        elif type == "CNAME":
+            content = self._fqdn_name(content)
+        return content
+
+    def _unclean_content(self, type, content):
+        if type in ("TXT", "LOC"):
+            content = content.strip('"')
+        elif type == "CNAME":
+            content = self._full_name(content)
+        return content
+
+    def create_record(self, type, name, content):
+        content = self._clean_content(type, content)
+        for rrset in self.zone_data()['rrsets']:
+            if rrset['name'] == name and rrset['type'] == type:
+                update_data = rrset
+                if 'comments' in update_data:
+                    del update_data['comments']
+                update_data['changetype'] = 'REPLACE'
+                break
+        else:
+            update_data = {
+                'name': name,
+                'type': type,
+                'records': [],
+                'ttl': self.options.get('ttl', 600),
+                'changetype': 'REPLACE'
+            }
+
+        for record in update_data['records']:
+            if record['content'] == content:
+                return True
+
+        update_data['records'].append({
+            'content': content,
+            'disabled': False
+        })
+
+        update_data['name'] = self._fqdn_name(update_data['name'])
+
+        request = {'rrsets': [update_data]}
+        print(request)
+
+        self._patch('/zones/' + self.options['domain'], data=request)
+        self._zone_data = None
+        return True
+
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        if identifier is not None:
+            type, name, content = self._parse_identifier(identifier)
+
+        print("delete {} {} {}".format(type, name, content))
+        if type is None or name is None:
+            raise Exception("Must specify at least both type and name")
+
+        for rrset in self.zone_data()['rrsets']:
+            if rrset['type'] == type and self._fqdn_name(rrset['name']) == self._fqdn_name(name):
+                update_data = rrset
+                if 'comments' in update_data:
+                    del update_data['comments']
+                update_data['changetype'] = 'REPLACE'
+                break
+        else:
+            return True
+
+        new_records = []
+        for record in update_data['records']:
+            if content is None or self._unclean_content(type, record['content']) != self._unclean_content(type, content):
+                new_records.append(record)
+
+        update_data['name'] = self._fqdn_name(update_data['name'])
+        update_data['records'] = new_records
+
+        request = {'rrsets': [update_data]}
+        print(request)
+
+        self._patch('/zones/' + self.options['domain'], data=request)
+        self._zone_data = None
+        return True
+
+    def update_record(self, identifier, type=None, name=None, content=None):
+        self.delete_record(identifier)
+        return self.create_record(type, name, content)
+
+    def _patch(self, url='/', data=None, query_params=None):
+        return self._request('PATCH', url, data=data, query_params=query_params)
+
+    def _request(self, action='GET', url='/', data=None, query_params=None):
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        r = requests.request(action, self.api_endpoint + url, params=query_params,
+                             data=json.dumps(data),
+                             headers={
+                                 'X-API-Key': self.api_key,
+                                 'Content-Type': 'application/json'
+                             })
+        print("response: " + r.text)
+        r.raise_for_status()
+        return r

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "example.com.",
+        "records": [{"content": "ns-internal.hhome.me. admin.hhome.me. 2017033111
+        28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type": "SOA"}],
+        "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['466']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,28 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/thisisadomainidonotown.com
+  response:
+    body: {string: !!python/unicode '{"error": "Could not find domain ''thisisadomainidonotown.com.''"}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['64']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      x-content-type-options: [nosniff]
+      x-frame-options: [deny]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block]
+    status: {code: 422, message: Unknown Status}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "example.com.",
+        "records": [{"content": "ns-internal.hhome.me. admin.hhome.me. 2017033111
+        28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type": "SOA"}],
+        "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['466']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "127.0.0.1", "disabled":
+      false}], "changetype": "REPLACE", "type": "A", "name": "localhost.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['156']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['601']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "docs.example.com.",
+      "disabled": false}], "changetype": "REPLACE", "type": "CNAME", "name": "docs.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['163']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,72 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['743']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "_acme-challenge.fqdn.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['900']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:39 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "_acme-challenge.full.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1057']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "_acme-challenge.test.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['178']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "delete.testfilt.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "delete.testfilt.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1366']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "delete.testfilt.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "delete.testfqdn.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "delete.testfqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1366']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "delete.testfqdn.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "delete.testfull.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "delete.testfull.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1366']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "delete.testfull.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:40 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "delete.testid.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['171']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "delete.testid.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1364']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "delete.testid.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['119']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,126 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1214']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"ttlshouldbe3600\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "ttl.fqdn.example.com.",
+      "ttl": 3600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['168']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1361']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1361']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "random.fqdntest.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1513']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1513']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "random.fulltest.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['173']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1665']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,137 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "docs.example.com.", "records": [{"content":
+        "docs.example.com.", "disabled": false}], "ttl": 600, "type": "CNAME"}, {"comments":
+        [], "name": "ttl.fqdn.example.com.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "example.com.", "records": [{"content": "ns-internal.hhome.me. admin.hhome.me.
+        2017033111 28800 7200 604800 86400", "disabled": false}], "ttl": 86400, "type":
+        "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api": "", "url":
+        "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1665']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "random.test.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['169']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1813']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1813']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:41 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,252 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1813']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "orig.test.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['167']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "orig.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1959']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "orig.test.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['115']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1813']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "updated.test.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['170']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,258 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1962']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "orig.testfqdn.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['171']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "orig.testfqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "ttl.fqdn.example.com.", "records":
+        [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl": 3600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['2112']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "orig.testfqdn.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['119']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "ttl.fqdn.example.com.",
+        "records": [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content":
+        "ns-internal.hhome.me. admin.hhome.me. 2017033111 28800 7200 604800 86400",
+        "disabled": false}], "ttl": 86400, "type": "SOA"}], "serial": 2017033111,
+        "soa_edit": "", "soa_edit_api": "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['1962']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "updated.testfqdn.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['174']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/powerdns/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,264 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "updated.testfqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "ttl.fqdn.example.com.", "records":
+        [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl": 3600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['2115']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:42 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "orig.testfull.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['171']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:43 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "updated.testfqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "ttl.fqdn.example.com.", "records":
+        [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl": 3600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "orig.testfull.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['2265']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:43 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"name": "orig.testfull.example.com.", "changetype":
+      "REPLACE", "records": [], "ttl": 600, "type": "TXT"}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['119']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:43 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode '{"account": "", "dnssec": false, "id": "example.com.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.com.",
+        "notified_serial": 0, "rrsets": [{"comments": [], "name": "localhost.example.com.",
+        "records": [{"content": "127.0.0.1", "disabled": false}], "ttl": 600, "type":
+        "A"}, {"comments": [], "name": "random.fqdntest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.fulltest.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "random.test.example.com.", "records": [{"content":
+        "\"challengetoken\"", "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "updated.test.example.com.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.com.", "records": [{"content": "docs.example.com.", "disabled":
+        false}], "ttl": 600, "type": "CNAME"}, {"comments": [], "name": "updated.testfqdn.example.com.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        600, "type": "TXT"}, {"comments": [], "name": "ttl.fqdn.example.com.", "records":
+        [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl": 3600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.fqdn.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.com.", "records":
+        [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 600, "type":
+        "TXT"}, {"comments": [], "name": "example.com.", "records": [{"content": "ns-internal.hhome.me.
+        admin.hhome.me. 2017033111 28800 7200 604800 86400", "disabled": false}],
+        "ttl": 86400, "type": "SOA"}], "serial": 2017033111, "soa_edit": "", "soa_edit_api":
+        "", "url": "api/v1/servers/localhost/zones/example.com."}'}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['2115']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      content-type: [application/json]
+      date: ['Fri, 31 Mar 2017 22:36:43 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"rrsets": [{"records": [{"content": "\"challengetoken\"",
+      "disabled": false}], "changetype": "REPLACE", "type": "TXT", "name": "updated.testfull.example.com.",
+      "ttl": 600}]}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['174']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: PATCH
+    uri: https://dnsadmin.hhome.me/api/v1/servers/localhost/zones/example.com
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      access-control-allow-origin: ['*']
+      connection: [keep-alive]
+      content-length: ['0']
+      content-security-policy: [default-src 'self'; style-src 'self' 'unsafe-inline']
+      content-security-policy-report-only: [default-src 'self'; script-src 'self'
+          'unsafe-inline']
+      date: ['Fri, 31 Mar 2017 22:36:43 GMT']
+      server: [nginx]
+      strict-transport-security: [max-age=15768000; includeSubDomains]
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [deny, SAMEORIGIN]
+      x-permitted-cross-domain-policies: [none]
+      x-xss-protection: [1; mode=block, 1; mode=block]
+    status: {code: 204, message: No Content}
+version: 1

--- a/tests/providers/test_powerdns.py
+++ b/tests/providers/test_powerdns.py
@@ -1,0 +1,16 @@
+from lexicon.providers.powerdns import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class PowerdnsProviderTests(TestCase, IntegrationTests):
+
+	Provider = Provider
+	provider_name = 'powerdns'
+	domain = 'example.com'
+
+	def _filter_headers(self):
+		return ['X-API-Key']


### PR DESCRIPTION
Implementation notes:
* The PowerDNS API does not assign a unique identifier to each record in the way
  that Lexicon expects. We work around this by creating an ID based on the record
  name, type and content, which when taken together are always unique
* The PowerDNS API has no notion of 'create a single record' or 'delete a single
  record'. All operations are either 'replace the RRSet with this new set of records'
  or 'delete all records for this name and type. Similarly, there is no notion of
  'change the content of this record', because records are identified by their name,
  type and content.
* The API is very picky about the format of values used when creating records, CNAMEs must be fully qualified and TXT, LOC records must be quoted.
  This is why the _clean_content and _unclean_content methods exist, to convert
  back and forth between the format PowerDNS expects, and the format Lexicon uses
