### PR TITLE
Addition of a Provider for Memset DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The current supported providers are:
 - Transip ([docs](https://www.transip.nl/transip/api/))
 - Yandex ([docs](https://tech.yandex.com/domain/doc/reference/dns-add-docpage/))
 - Vultr ([docs](https://www.vultr.com/api/))
+- Memset ([docs](https://www.memset.com/apidocs/methods_dns.html))
 
 Potential providers are as follows. If you would like to contribute one, please open a pull request.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The current supported providers are:
 - Glesys ([docs](https://github.com/glesys/API/wiki/functions_domain))
 - Gandi ([docs](http://doc.rpc.gandi.net/))
 - LuaDNS ([docs](http://www.luadns.com/api.html))
+- Memset ([docs](https://www.memset.com/apidocs/methods_dns.html))
 - Namesilo ([docs](https://www.namesilo.com/api_reference.php))
 - NS1 ([docs](https://ns1.com/api/))
 - PointHQ ([docs](https://pointhq.com/api/docs))
@@ -41,7 +42,6 @@ The current supported providers are:
 - Transip ([docs](https://www.transip.nl/transip/api/))
 - Yandex ([docs](https://tech.yandex.com/domain/doc/reference/dns-add-docpage/))
 - Vultr ([docs](https://www.vultr.com/api/))
-- Memset ([docs](https://www.memset.com/apidocs/methods_dns.html))
 
 Potential providers are as follows. If you would like to contribute one, please open a pull request.
 

--- a/lexicon/providers/memset.py
+++ b/lexicon/providers/memset.py
@@ -1,0 +1,121 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from .base import Provider as BaseProvider
+import requests
+import json
+from pprint import pprint
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-token", help="specify API key used to authenticate")
+
+
+class Provider(BaseProvider):
+    def __init__(self, options, provider_options={}):
+        super(Provider, self).__init__(options)
+        self.domain_id = None
+        self.api_endpoint = provider_options.get('api_endpoint') or 'https://api.memset.com/v1/json'
+
+    def authenticate(self):
+        payload = self._get('/dns.zone_domain_info', {
+            'domain': self.options['domain']
+        })
+        if not payload['zone_id']:
+            raise Exception('No domain found')
+        self.domain_id = payload['zone_id']
+
+    # Create record. If record already exists with the same content, do nothing'
+    def create_record(self, type, name, content):
+        data = {'type': type, 'record': self._relative_name(name), 'address': content}
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
+        data['zone_id'] = self.domain_id
+        check_exists = self.list_records(type=type, name=name, content=content)
+        if not len(check_exists) > 0:
+            payload = self._get('/dns.zone_record_create', data)
+            if payload['id']:
+                self._get('/dns.reload')
+                print('create_record: {0}'.format(payload['id']))
+                return payload['id']
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        payload = self._get('/dns.zone_info', {
+            'id': self.domain_id
+            })
+        records = []
+        for record in payload['records']:
+            processed_record = {
+                'type': record['type'],
+                'name': self._full_name(record['record']),
+                'ttl': record['ttl'],
+                'content': record['address'],
+                'id': record['id']
+            }
+            if name:
+                name = self._full_name(name)
+            if (processed_record['type'] == type):
+                if (name is not None and content is not None):
+                    if processed_record['name'] == name and processed_record['content'] == content:
+                        records.append(processed_record)
+                elif (name is not None and content is None):
+                    if processed_record['name'] == name:
+                        records.append(processed_record)
+                elif (name is None and content is not None):
+                    if processed_record['content'] == content:
+                        records.append(processed_record)
+                else:
+                    records.append(processed_record)
+
+        print('list_records: {0}'.format(records))
+        return records
+
+    # Create or update a record.
+    def update_record(self, identifier, type=None, name=None, content=None):
+        data = {}
+        if type:
+            data['type'] = type
+        if name:
+            data['record'] = self._relative_name(name)
+        if content:
+            data['address'] = content
+        if self.options.get('ttl'):
+            data['ttl'] = self.options.get('ttl')
+        data['id'] = identifier
+        data['zone_id'] = self.domain_id
+
+        payload = self._get('/dns.zone_record_update', data)
+        if payload['id']:
+            self._get('/dns.reload')
+            print('update_record: {0}'.format(payload['id']))
+            return payload['id']
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        if not identifier:
+            records = self.list_records(type, self._relative_name(name), content)
+            if len(records) == 1:
+                identifier = records[0]['id']
+            else:
+                raise Exception('Record identifier could not be found.')
+        payload = self._get('/dns.zone_record_delete', {'id': identifier})
+        if payload['id']:
+            self._get('/dns.reload')
+            print('delete_record: {0}'.format(payload['id']))
+            return payload['id']
+
+    # Helpers
+    def _request(self, action='GET',  url='/', data=None, query_params=None):
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        r = requests.request(action, self.api_endpoint + url, params=query_params,
+                             data=json.dumps(data),
+                             auth=(self.options['auth_token'], 'x'),
+                             headers={'Content-Type': 'application/json'})
+        r.raise_for_status()  # if the request fails for any reason, throw an error.
+        return r.json()

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=thisisadomainidonotown.com
+  response:
+    body: {string: !!python/unicode "{\n \"error_type\": \"ApiErrorDoesNotExist\"\
+        , \n \"error_code\": 3, \n \"error\": \"Zone domain not found\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 404, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,91 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=localhost&type=A&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=127.0.0.1
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"127.0.0.1\", \n \"relative\": false, \n \"record\": \"\
+        localhost\", \n \"ttl\": 0, \n \"type\": \"A\", \n \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"30796ed788e32b40c7c2237610ba6235\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=docs&type=CNAME&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=docs.example.com
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"docs.example.com\", \n \"relative\": false, \n \"record\"\
+        : \"docs\", \n \"ttl\": 0, \n \"type\": \"CNAME\", \n \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"b32d91e3418534f124ca4f5fd7fd4f74\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.fqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"_acme-challenge.fqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
+        : \"7dad5e5595a27b60a9617da1f1a5165c\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"b1a6a4c3c38bbce04d806925ab718d53\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.full&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"_acme-challenge.full\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
+        : \"b3cfe8902774a8768b4acabaae1ac245\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"3b6d8c88b0c50bd5bca56b7c66050bd5\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"_acme-challenge.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
+        : \"beefd8ad7b4db90995f0775827c7f2f9\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"0da8317e8a4abe7682d485e478d259d3\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfilt&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfilt\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        451cb31d379daa8f460674b6f02e5501\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"583bd91015f4cc04aa79c1948f40992b\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"delete.testfilt\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"451cb31d379daa8f460674b6f02e5501\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=451cb31d379daa8f460674b6f02e5501
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfilt\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        451cb31d379daa8f460674b6f02e5501\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"3624331d4f43ac4ecf5cad243fae8882\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        8109c7bb1e3c71e200b66f908e5ee3ec\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"b5bf5eefec55cb44fe55237c6132411c\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"delete.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"8109c7bb1e3c71e200b66f908e5ee3ec\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=8109c7bb1e3c71e200b66f908e5ee3ec
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        8109c7bb1e3c71e200b66f908e5ee3ec\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"395c02c2fa27cc4f148c766aeb459add\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfull&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        e2401170ef7b4b1c2dfd5eac0883cb29\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"35fb397f130207e2cfee7efbb2fc2882\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"delete.testfull\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"e2401170ef7b4b1c2dfd5eac0883cb29\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=e2401170ef7b4b1c2dfd5eac0883cb29
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        e2401170ef7b4b1c2dfd5eac0883cb29\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"c143e1f7220f1f629dd16c0e549d8817\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testid&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"ade838f87398440b8b392877006b8b9a\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"delete.testid\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
+        \  \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=36dd8d82f2b9543e28a1859371d84dc5
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"23f9c67e0f9d84ff0845e258b8348d6a\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,153 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=ttl.fqdn&ttl=3600&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=ttlshouldbe3600
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"ttlshouldbe3600\", \n \"relative\": false, \n \"record\"\
+        : \"ttl.fqdn\", \n \"ttl\": 3600, \n \"type\": \"TXT\", \n \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"da61170727d3529ba6e272eb3eab4f93\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,160 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.fqdntest&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"random.fqdntest\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        cfed30ca5d5ee6b73547b450534d3da2\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"a299ab269f055a5fbbd35ed2eba5a946\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,167 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.fulltest&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"random.fulltest\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"197036eacb59868f32fa6def5eecbedb\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,174 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"random.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"11fb698820740c658946de3f20541db1\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"orig.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"7c069b2324d3312bc4e27f8af606c873\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"orig.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.test&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=41cb6ef836e57b9958863d6d261700c1&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"updated.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"1f9708e7397792287e41a3f6fc29e07f\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,233 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
+        \ \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"orig.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"8815c7212ceb7b0cf6b50d181c1aebbe\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"orig.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
+        \  \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfqdn&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=cd59db899b0e6ae8051b6aaa4838497a&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"updated.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        cd59db899b0e6ae8051b6aaa4838497a\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"15168be30c7d7dbeb33f41effc6352bf\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,240 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
+  response:
+    body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
+        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
+        \ \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.testfqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfull&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"orig.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"d45414b637da6771ba5edac85c58f5a8\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"81366be83a03bc8657bca0b4102424d5\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"orig.testfull\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
+        \  \"id\": \"d45414b637da6771ba5edac85c58f5a8\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfull&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=d45414b637da6771ba5edac85c58f5a8&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"updated.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        d45414b637da6771ba5edac85c58f5a8\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"f75cfe147c04f87450f79b359883255f\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Sat, 01 Apr 2017 12:24:02 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_memset.py
+++ b/tests/providers/test_memset.py
@@ -1,0 +1,18 @@
+# Test for one implementation of the interface
+from lexicon.providers.memset import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class MemsetProviderTests(TestCase, IntegrationTests):
+
+    Provider = Provider
+    provider_name = 'memset'
+    domain = 'testzone.com'
+
+    def _filter_headers(self):
+        return ['Authorization']


### PR DESCRIPTION
A nice straightforward implementation.

Records are presented relative to the bare domain by default, so some ```self._relative_name``` and ```self._full_name``` trickery was required.