### PR TITLE
[FIX] Update did not actually find the identifier correctly if not passed in specifically

### DIFF
--- a/lexicon/providers/memset.py
+++ b/lexicon/providers/memset.py
@@ -74,6 +74,13 @@ class Provider(BaseProvider):
     # Create or update a record.
     def update_record(self, identifier, type=None, name=None, content=None):
         data = {}
+        if not identifier:
+            records = self.list_records(type, self._relative_name(name))
+            print(records)
+            if len(records) == 1:
+                identifier = records[0]['id']
+            else:
+                raise Exception('Record identifier could not be found.')
         if type:
             data['type'] = type
         if name:


### PR DESCRIPTION
I missed this in testing - it will now find the identifier when updating, as it does when deleting.