### PR TITLE
[ADD] Added test to check for DNS record update without ID

### DIFF
--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:00 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -16,7 +16,7 @@ interactions:
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:00 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 404, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:42 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:00 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,16 +30,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:01 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -53,16 +53,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=localhost&type=A&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=127.0.0.1
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=localhost&type=A&zone_id=cbceea86fe9c099f019e386488ead6d8&address=127.0.0.1
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"127.0.0.1\", \n \"relative\": false, \n \"record\": \"\
-        localhost\", \n \"ttl\": 0, \n \"type\": \"A\", \n \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
+        localhost\", \n \"ttl\": 0, \n \"type\": \"A\", \n \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:01 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -79,12 +79,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"30796ed788e32b40c7c2237610ba6235\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"eb440a9c9321c0ed2c55849b4ca74550\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:01 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:01 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,19 +30,19 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
-        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:43 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:01 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -56,16 +56,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=docs&type=CNAME&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=docs.example.com
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=docs&type=CNAME&zone_id=cbceea86fe9c099f019e386488ead6d8&address=docs.example.com
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"docs.example.com\", \n \"relative\": false, \n \"record\"\
-        : \"docs\", \n \"ttl\": 0, \n \"type\": \"CNAME\", \n \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
+        : \"docs\", \n \"ttl\": 0, \n \"type\": \"CNAME\", \n \"id\": \"5554241a3076d14abf34f28784691705\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:02 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -82,12 +82,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"b32d91e3418534f124ca4f5fd7fd4f74\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"00429c3c4dfd25851ea627996fc332a9\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:02 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:02 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,23 +30,23 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:02 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -60,16 +60,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.fqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.fqdn&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"_acme-challenge.fqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
-        : \"7dad5e5595a27b60a9617da1f1a5165c\"\n}"}
+        : \"2bd6771488f82a3cfd063ff115876291\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:44 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:03 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -86,12 +86,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"b1a6a4c3c38bbce04d806925ab718d53\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"959f53d1aa899d6fbca55d694a7fd3c9\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:03 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:03 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,27 +30,27 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:03 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -64,16 +64,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.full&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.full&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"_acme-challenge.full\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
-        : \"b3cfe8902774a8768b4acabaae1ac245\"\n}"}
+        : \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:03 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -90,12 +90,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"3b6d8c88b0c50bd5bca56b7c66050bd5\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"d16ea2260c081e85c694eea89498a98c\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:04 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:45 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:04 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,30 +30,30 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:04 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -67,16 +67,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=_acme-challenge.test&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"_acme-challenge.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\"\
-        : \"beefd8ad7b4db90995f0775827c7f2f9\"\n}"}
+        : \"c387e145c305648a0636fc7042fd4b01\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:04 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -93,12 +93,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"0da8317e8a4abe7682d485e478d259d3\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"e0f18b2254a92e7cb751d7af37cfde2c\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:04 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:05 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,34 +30,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:46 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:05 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -71,16 +71,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfilt&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfilt&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfilt\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        451cb31d379daa8f460674b6f02e5501\"\n}"}
+        04de67efb16b1959bad263e30c4cea52\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:05 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -97,12 +97,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"583bd91015f4cc04aa79c1948f40992b\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"d8f68154e47241106ee320be25938e07\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:05 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -116,37 +116,37 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"delete.testfilt\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"451cb31d379daa8f460674b6f02e5501\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"04de67efb16b1959bad263e30c4cea52\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"5554241a3076d14abf34f28784691705\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
-        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:05 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -160,16 +160,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=451cb31d379daa8f460674b6f02e5501
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=04de67efb16b1959bad263e30c4cea52
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfilt\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        451cb31d379daa8f460674b6f02e5501\"\n}"}
+        04de67efb16b1959bad263e30c4cea52\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:06 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -186,12 +186,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"3624331d4f43ac4ecf5cad243fae8882\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"9c66245aa0cf65295803ee110893774f\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:47 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:06 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -205,34 +205,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:06 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:06 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,34 +30,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:06 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -71,16 +71,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfqdn&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        8109c7bb1e3c71e200b66f908e5ee3ec\"\n}"}
+        ca3de87a7f9d3817bbce013b01a76705\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:07 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -97,12 +97,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"b5bf5eefec55cb44fe55237c6132411c\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"458235d46591168dc70fccb5fe1a78f4\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:48 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:07 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -116,37 +116,37 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"delete.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"8109c7bb1e3c71e200b66f908e5ee3ec\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"ca3de87a7f9d3817bbce013b01a76705\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"5554241a3076d14abf34f28784691705\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
-        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:07 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -160,16 +160,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=8109c7bb1e3c71e200b66f908e5ee3ec
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=ca3de87a7f9d3817bbce013b01a76705
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        8109c7bb1e3c71e200b66f908e5ee3ec\"\n}"}
+        ca3de87a7f9d3817bbce013b01a76705\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:07 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -186,12 +186,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"395c02c2fa27cc4f148c766aeb459add\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"d75428d218823a006652fc9ca0ec44a9\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:07 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -205,34 +205,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:08 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:49 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:08 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,34 +30,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:08 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -71,16 +71,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfull&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testfull&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        e2401170ef7b4b1c2dfd5eac0883cb29\"\n}"}
+        9fa35393ef612a039e9cbafe7296706a\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:08 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -97,12 +97,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"35fb397f130207e2cfee7efbb2fc2882\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"b66760d4999d3b434ece0b44ae21dd3c\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:08 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -116,37 +116,37 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"delete.testfull\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"e2401170ef7b4b1c2dfd5eac0883cb29\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"9fa35393ef612a039e9cbafe7296706a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"5554241a3076d14abf34f28784691705\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
-        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:09 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -160,16 +160,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=e2401170ef7b4b1c2dfd5eac0883cb29
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=9fa35393ef612a039e9cbafe7296706a
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"delete.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        e2401170ef7b4b1c2dfd5eac0883cb29\"\n}"}
+        9fa35393ef612a039e9cbafe7296706a\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:50 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:09 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -186,12 +186,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"c143e1f7220f1f629dd16c0e549d8817\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"06758942c3acbbaa74f2a2332a3538cb\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:09 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -205,34 +205,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:09 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:09 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,34 +30,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -71,16 +71,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testid&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=delete.testid&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\
+        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"264ab819cfd422566be7f8969a8dc204\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:51 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -97,12 +97,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"ade838f87398440b8b392877006b8b9a\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"99c1eeaead891de6922829e83960c394\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -116,37 +116,37 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"delete.testid\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
-        \  \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \  \"id\": \"264ab819cfd422566be7f8969a8dc204\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"docs.example.com\", \n   \"relative\": false, \n   \"record\": \"docs\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"6661a42d3bc41cfedcace1bd13268fe4\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\": \"5554241a3076d14abf34f28784691705\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"127.0.0.1\", \n   \"relative\": false, \n   \"record\"\
-        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        : \"localhost\", \n   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -160,16 +160,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=36dd8d82f2b9543e28a1859371d84dc5
+    uri: https://api.memset.com/v1/json/dns.zone_record_delete?id=264ab819cfd422566be7f8969a8dc204
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"36dd8d82f2b9543e28a1859371d84dc5\"\
+        : \"delete.testid\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"264ab819cfd422566be7f8969a8dc204\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -186,12 +186,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"23f9c67e0f9d84ff0845e258b8348d6a\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"bd67a3c33b10b6a61e1031b11aa13eb0\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:10 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -205,34 +205,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:52 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:11 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:11 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,34 +30,34 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:11 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -71,16 +71,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=ttl.fqdn&ttl=3600&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=ttlshouldbe3600
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=ttl.fqdn&ttl=3600&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=ttlshouldbe3600
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"ttlshouldbe3600\", \n \"relative\": false, \n \"record\"\
-        : \"ttl.fqdn\", \n \"ttl\": 3600, \n \"type\": \"TXT\", \n \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
+        : \"ttl.fqdn\", \n \"ttl\": 3600, \n \"type\": \"TXT\", \n \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:11 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -97,12 +97,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"da61170727d3529ba6e272eb3eab4f93\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"c9297286994e75d4b1e2af3f08b5be67\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:53 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:11 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -116,37 +116,37 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:54 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:12 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:13 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,41 +30,41 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:13 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -78,16 +78,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.fulltest&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.fulltest&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
         : \"random.fulltest\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n}"}
+        9cbbe78eedfbbb49620a9d46a192b64b\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:13 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -104,12 +104,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"197036eacb59868f32fa6def5eecbedb\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"687230d6dcf8994444ecb996b4e535e1\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:55 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:14 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -123,44 +123,44 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:14 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:14 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,44 +30,44 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:14 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -81,16 +81,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.test&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"random.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
+        : \"random.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"bafe455721c0bf6d98a8886fe4662466\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:14 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -107,12 +107,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"11fb698820740c658946de3f20541db1\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"8bf9d36d504aea5f6065151efb7fc50d\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:56 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:15 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -126,48 +126,48 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:15 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:15 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,48 +30,48 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:15 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:57 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:15 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,48 +30,48 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -85,16 +85,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.test&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.test&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"orig.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        : \"orig.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -111,12 +111,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"7c069b2324d3312bc4e27f8af606c873\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"d90352c3ee1eddf6736ef0a4a5345051\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -130,51 +130,51 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"orig.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"bafe455721c0bf6d98a8886fe4662466\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -188,16 +188,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.test&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=41cb6ef836e57b9958863d6d261700c1&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.test&zone_id=cbceea86fe9c099f019e386488ead6d8&type=TXT&id=9fc1f0b1e9ab81462031e49ecce27a6b&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"updated.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
+        : \"updated.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\
         \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:58 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -214,12 +214,12 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"1f9708e7397792287e41a3f6fc29e07f\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"f2aa037e7a78f8b176ac32736d89dca4\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:16 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -16,96 +16,7 @@ interactions:
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Thu, 13 Apr 2017 12:57:12 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
-  response:
-    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
-        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
-        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
-        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
-        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
-        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
-        , \n \"ttl\": 0\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Thu, 13 Apr 2017 12:57:12 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=random.fqdntest&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
-  response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
-        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"random.fqdntest\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        f7ca834ea50f9b87824e12e3d38e5593\"\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Thu, 13 Apr 2017 12:57:12 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.reload
-  response:
-    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"bdcb87e37dc1edb97371eceba20586ca\", \n\
-        \ \"error\": false\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Thu, 13 Apr 2017 12:57:12 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:17 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -135,8 +46,125 @@ interactions:
         record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
         \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
         : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
         , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
+        \ \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:17 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.nameonly.test&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"orig.nameonly.test\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\":\
+        \ \"0cd1a5deb2cedb691b9f298ee26d1158\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:17 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"4065f604000f0131bf84fc325ffcff2c\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:17 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"orig.nameonly.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"bafe455721c0bf6d98a8886fe4662466\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
+        record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\
         \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
@@ -153,7 +181,52 @@ interactions:
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Thu, 13 Apr 2017 12:57:13 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:18 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=orig.nameonly.test&zone_id=cbceea86fe9c099f019e386488ead6d8&type=TXT&id=0cd1a5deb2cedb691b9f298ee26d1158&address=updated
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"address\": \"updated\", \n \"relative\": false, \n \"record\": \"orig.nameonly.test\"\
+        , \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\
+        \n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:18 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"0c5655441198ccf09514fe0c6f514d64\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:18 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:18 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,158 +30,55 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
-        \ \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n \"ttl\": 0\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfqdn&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
-  response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"orig.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\
-        \n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.reload
-  response:
-    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"8815c7212ceb7b0cf6b50d181c1aebbe\", \n\
-        \ \"error\": false\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:23:59 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
-  response:
-    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
-        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
-        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"orig.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
-        \  \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"updated\", \n   \"relative\": false, \n   \"record\"\
+        : \"orig.nameonly.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"bafe455721c0bf6d98a8886fe4662466\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
         ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:19 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -195,16 +92,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfqdn&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=cd59db899b0e6ae8051b6aaa4838497a&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfqdn&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"updated.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        cd59db899b0e6ae8051b6aaa4838497a\"\n}"}
+        : \"orig.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"0377514f1b75d39fb43adfeb79f91d0c\"\
+        \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:19 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -221,12 +118,122 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"15168be30c7d7dbeb33f41effc6352bf\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"ad1697d655b18875c7219488d6a6cd18\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:19 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"updated\", \n   \"relative\": false, \n   \"record\"\
+        : \"orig.nameonly.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"orig.testfqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"0377514f1b75d39fb43adfeb79f91d0c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
+        \ \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:19 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfqdn&zone_id=cbceea86fe9c099f019e386488ead6d8&type=TXT&id=0377514f1b75d39fb43adfeb79f91d0c&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"updated.testfqdn\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        0377514f1b75d39fb43adfeb79f91d0c\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:19 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"6385472c1bd0993ce33fff933005eaea\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:20 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/memset/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -12,11 +12,11 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.zone_domain_info?domain=testzone.com
   response:
     body: {string: !!python/unicode "{\n \"domain\": \"testzone.com\", \n \"zone_id\"\
-        : \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n}"}
+        : \"cbceea86fe9c099f019e386488ead6d8\"\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:20 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -30,165 +30,58 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
   response:
     body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
         record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
         127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"c30236e859dd65002ccc1c774ac4277b\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
-        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"67f1d3925c27583aa8e10b9b60efa120\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
-        \ \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.testfqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
-        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\n  }\n ], \n \"nickname\"\
-        : \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n \"\
-        ttl\": 0\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:00 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfull&type=TXT&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&address=challengetoken
-  response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"orig.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"d45414b637da6771ba5edac85c58f5a8\"\
-        \n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.reload
-  response:
-    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"81366be83a03bc8657bca0b4102424d5\", \n\
-        \ \"error\": false\n}"}
-    headers:
-      connection: [keep-alive]
-      content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
-      server: [nginx]
-      transfer-encoding: [chunked]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode '{}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2']
-      Content-Type: [application/json]
-      User-Agent: [python-requests/2.13.0]
-    method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_info?id=ce64e02f2e2e893bdf14703bb8bef9c3
-  response:
-    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
-        , \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\n  }\n ], \n \"records\"\
-        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
-        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
-        : \"6661a42d3bc41cfedcace1bd13268fe4\"\n  }, \n  {\n   \"priority\": 0, \n\
-        \   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\": \"\
-        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
-        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"0403869cf4b27d4043907dfc0ffcffc6\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
-        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
-        record\": \"orig.testfull\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n \
-        \  \"id\": \"d45414b637da6771ba5edac85c58f5a8\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"updated\", \n   \"relative\": false, \n   \"record\"\
+        : \"orig.nameonly.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fqdntest\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"cfed30ca5d5ee6b73547b450534d3da2\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"random.fulltest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"a3962e3a539afd1ba0bc7d2bf1c7a3c9\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c30236e859dd65002ccc1c774ac4277b\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"bafe455721c0bf6d98a8886fe4662466\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"\
         record\": \"ttl.fqdn\", \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"\
-        id\": \"67f1d3925c27583aa8e10b9b60efa120\"\n  }, \n  {\n   \"priority\": 0,\
-        \ \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"41cb6ef836e57b9958863d6d261700c1\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"updated.testfqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
-        \   \"id\": \"cd59db899b0e6ae8051b6aaa4838497a\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        \   \"id\": \"0377514f1b75d39fb43adfeb79f91d0c\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.fqdn\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"7dad5e5595a27b60a9617da1f1a5165c\"\
-        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
         record\": \"_acme-challenge.full\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
-        , \n   \"id\": \"b3cfe8902774a8768b4acabaae1ac245\"\n  }, \n  {\n   \"priority\"\
-        : 0, \n   \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\", \n   \"address\"\
+        , \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
         : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.test\"\
-        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"beefd8ad7b4db90995f0775827c7f2f9\"\
-        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\
+        \n  }\n ], \n \"nickname\": \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"ttl\": 0\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:20 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -202,16 +95,16 @@ interactions:
       Content-Type: [application/json]
       User-Agent: [python-requests/2.13.0]
     method: GET
-    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfull&zone_id=ce64e02f2e2e893bdf14703bb8bef9c3&type=TXT&id=d45414b637da6771ba5edac85c58f5a8&address=challengetoken
+    uri: https://api.memset.com/v1/json/dns.zone_record_create?record=orig.testfull&type=TXT&zone_id=cbceea86fe9c099f019e386488ead6d8&address=challengetoken
   response:
-    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"ce64e02f2e2e893bdf14703bb8bef9c3\"\
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
         , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
-        : \"updated.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
-        d45414b637da6771ba5edac85c58f5a8\"\n}"}
+        : \"orig.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"c3d8ccd026a1db55fa996b300ccf1efe\"\
+        \n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:01 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:20 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}
@@ -228,12 +121,126 @@ interactions:
     uri: https://api.memset.com/v1/json/dns.reload
   response:
     body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
-        \ \n \"type\": \"dns\", \n \"id\": \"f75cfe147c04f87450f79b359883255f\", \n\
+        \ \n \"type\": \"dns\", \n \"id\": \"6a506142529188492721809a5b9dfa9d\", \n\
         \ \"error\": false\n}"}
     headers:
       connection: [keep-alive]
       content-type: [application/json]
-      date: ['Sat, 01 Apr 2017 12:24:02 GMT']
+      date: ['Thu, 13 Apr 2017 12:57:20 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_info?id=cbceea86fe9c099f019e386488ead6d8
+  response:
+    body: {string: !!python/unicode "{\n \"domains\": [\n  {\n   \"domain\": \"testzone.com\"\
+        , \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\n  }\n ], \n \"records\"\
+        : [\n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"docs.example.com\", \n   \"relative\": false, \n   \"\
+        record\": \"docs\", \n   \"ttl\": 0, \n   \"type\": \"CNAME\", \n   \"id\"\
+        : \"5554241a3076d14abf34f28784691705\"\n  }, \n  {\n   \"priority\": 0, \n\
+        \   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\": \"\
+        127.0.0.1\", \n   \"relative\": false, \n   \"record\": \"localhost\", \n\
+        \   \"ttl\": 0, \n   \"type\": \"A\", \n   \"id\": \"6b3f0b55cff3843c1c592be27db44a66\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"updated\", \n   \"relative\": false, \n   \"record\"\
+        : \"orig.nameonly.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"0cd1a5deb2cedb691b9f298ee26d1158\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"orig.testfull\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"c3d8ccd026a1db55fa996b300ccf1efe\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.fqdntest\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n\
+        \   \"id\": \"f7ca834ea50f9b87824e12e3d38e5593\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"random.fulltest\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"9cbbe78eedfbbb49620a9d46a192b64b\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"random.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"\
+        id\": \"bafe455721c0bf6d98a8886fe4662466\"\n  }, \n  {\n   \"priority\": 0,\
+        \ \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"ttlshouldbe3600\", \n   \"relative\": false, \n   \"record\": \"ttl.fqdn\"\
+        , \n   \"ttl\": 3600, \n   \"type\": \"TXT\", \n   \"id\": \"71c8b68c98cc8fbfdbb1eabb4b8a3617\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"updated.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n  \
+        \ \"id\": \"9fc1f0b1e9ab81462031e49ecce27a6b\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"updated.testfqdn\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"0377514f1b75d39fb43adfeb79f91d0c\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.fqdn\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"2bd6771488f82a3cfd063ff115876291\"\n  }, \n  {\n   \"priority\"\
+        : 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\", \n   \"address\"\
+        : \"challengetoken\", \n   \"relative\": false, \n   \"record\": \"_acme-challenge.full\"\
+        , \n   \"ttl\": 0, \n   \"type\": \"TXT\", \n   \"id\": \"2b9ad50bff5f8479bbbda0ef1919d25a\"\
+        \n  }, \n  {\n   \"priority\": 0, \n   \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n   \"address\": \"challengetoken\", \n   \"relative\": false, \n   \"\
+        record\": \"_acme-challenge.test\", \n   \"ttl\": 0, \n   \"type\": \"TXT\"\
+        , \n   \"id\": \"c387e145c305648a0636fc7042fd4b01\"\n  }\n ], \n \"nickname\"\
+        : \"testzone.com\", \n \"id\": \"cbceea86fe9c099f019e386488ead6d8\", \n \"\
+        ttl\": 0\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:21 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.zone_record_update?record=updated.testfull&zone_id=cbceea86fe9c099f019e386488ead6d8&type=TXT&id=c3d8ccd026a1db55fa996b300ccf1efe&address=challengetoken
+  response:
+    body: {string: !!python/unicode "{\n \"priority\": 0, \n \"zone_id\": \"cbceea86fe9c099f019e386488ead6d8\"\
+        , \n \"address\": \"challengetoken\", \n \"relative\": false, \n \"record\"\
+        : \"updated.testfull\", \n \"ttl\": 0, \n \"type\": \"TXT\", \n \"id\": \"\
+        c3d8ccd026a1db55fa996b300ccf1efe\"\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:21 GMT']
+      server: [nginx]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.13.0]
+    method: GET
+    uri: https://api.memset.com/v1/json/dns.reload
+  response:
+    body: {string: !!python/unicode "{\n \"status\": \"NEW\", \n \"finished\": false,\
+        \ \n \"type\": \"dns\", \n \"id\": \"d25b981c6f07ac5646f248686323fd3a\", \n\
+        \ \"error\": false\n}"}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json]
+      date: ['Thu, 13 Apr 2017 12:57:21 GMT']
       server: [nginx]
       transfer-encoding: [chunked]
     status: {code: 200, message: OK}

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -212,6 +212,17 @@ class IntegrationTests(object):
             records = provider.list_records('TXT','orig.test')
             assert provider.update_record(records[0].get('id', None),'TXT','updated.test','challengetoken')
 
+    def test_Provider_when_calling_update_record_should_modify_record_name_specified(self):
+        with provider_vcr.use_cassette(self._cassette_path('IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml'), filter_headers=self._filter_headers(), filter_query_parameters=self._filter_query_parameters(), filter_post_data_parameters=self._filter_post_data_parameters()):
+            provider = self.Provider({
+                'domain': self.domain,
+                'auth_username': self._auth_username(),
+                'auth_token': self._auth_token()
+            }, self.provider_opts)
+            provider.authenticate()
+            assert provider.create_record('TXT','orig.nameonly.test','challengetoken')
+            assert provider.update_record(None,'TXT','orig.nameonly.test','updated')
+
     def test_Provider_when_calling_update_record_with_full_name_should_modify_record(self):
         with provider_vcr.use_cassette(self._cassette_path('IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml'), filter_headers=self._filter_headers(), filter_query_parameters=self._filter_query_parameters(), filter_post_data_parameters=self._filter_post_data_parameters()):
             provider = self.Provider({


### PR DESCRIPTION
     - Does not run first 'list' operation to get the identifier, just relies on the name that is specified

This PR proposes an additional test, requested in comments of #118: ```test_Provider_when_calling_update_record_should_modify_record_name_specified``` which will update the content of record just based on its name (use case = dynamic dns?)