### PR TITLE
Switch print to logging

### DIFF
--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
+
 import argparse
-import os
 import importlib
-import sys
-from .client import Client
+import os
+
 import pkg_resources
+
+from .client import Client
+
+
 #based off https://docs.python.org/2/howto/argparse.html
 
 

--- a/lexicon/__main__.py
+++ b/lexicon/__main__.py
@@ -4,14 +4,17 @@ from __future__ import print_function
 
 import argparse
 import importlib
+import logging
 import os
+import sys
 
 import pkg_resources
 
 from .client import Client
 
-
 #based off https://docs.python.org/2/howto/argparse.html
+
+logger = logging.getLogger(__name__)
 
 
 def BaseProviderParser():
@@ -58,8 +61,10 @@ def MainParser():
 
 #dynamically determine all the providers available.
 def main():
+    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='%(message)s')
+
     parsed_args = MainParser().parse_args()
-    print(parsed_args)
+    logger.debug('Arguments: %s', parsed_args)
     client = Client(parsed_args.__dict__)
     client.execute()
 

--- a/lexicon/providers/base.py
+++ b/lexicon/providers/base.py
@@ -1,5 +1,8 @@
 from builtins import object
+
 from ..common.options_handler import SafeOptionsWithFallback
+
+
 class Provider(object):
 
     """

--- a/lexicon/providers/cloudflare.py
+++ b/lexicon/providers/cloudflare.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify email address used to authenticate")

--- a/lexicon/providers/cloudflare.py
+++ b/lexicon/providers/cloudflare.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -41,7 +44,7 @@ class Provider(BaseProvider):
             data['ttl'] = self.options.get('ttl')
         payload = self._post('/zones/{0}/dns_records'.format(self.domain_id), data)
 
-        print('create_record: {0}'.format(payload['success']))
+        logger.debug('create_record: %s', payload['success'])
         return payload['success']
 
     # List all records. Return an empty list if no records found
@@ -69,7 +72,7 @@ class Provider(BaseProvider):
             }
             records.append(processed_record)
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -87,7 +90,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/zones/{0}/dns_records/{1}'.format(self.domain_id, identifier), data)
 
-        print('update_record: {0}'.format(payload['success']))
+        logger.debug('update_record: %s', payload['success'])
         return payload['success']
 
     # Delete an existing record.
@@ -95,14 +98,14 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug("records: %s", records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
                 raise Exception('Record identifier could not be found.')
         payload = self._delete('/zones/{0}/dns_records/{1}'.format(self.domain_id, identifier))
 
-        print('delete_record: {0}'.format(payload['success']))
+        logger.debug('delete_record: %s', payload['success'])
         return payload['success']
 
 

--- a/lexicon/providers/cloudxns.py
+++ b/lexicon/providers/cloudxns.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
-import json
-import time
-import hashlib
+from __future__ import print_function
 from future.standard_library import install_aliases
 install_aliases()
+
+import hashlib
+import json
+import time
+
+import requests
+
+from .base import Provider as BaseProvider
+
 from urllib.parse import urlencode
 
 

--- a/lexicon/providers/cloudxns.py
+++ b/lexicon/providers/cloudxns.py
@@ -6,6 +6,7 @@ install_aliases()
 
 import hashlib
 import json
+import logging
 import time
 
 import requests
@@ -13,6 +14,8 @@ import requests
 from .base import Provider as BaseProvider
 
 from urllib.parse import urlencode
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -52,7 +55,7 @@ class Provider(BaseProvider):
 
         payload = self._post('/record', record)
 
-        print('create_record: {0}'.format(True)) # CloudXNS will return bad HTTP Status when error, will throw at r.raise_for_status() in _request()
+        logger.debug('create_record: %s', True) # CloudXNS will return bad HTTP Status when error, will throw at r.raise_for_status() in _request()
         return True
 
     # List all records. Return an empty list if no records found
@@ -84,7 +87,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -108,7 +111,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/record/' + identifier, data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -125,7 +128,7 @@ class Provider(BaseProvider):
         payload = self._delete('/record/' + identifier + '/' + self.domain_id)
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/digitalocean.py
+++ b/lexicon/providers/digitalocean.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify token used authenticate to DNS provider")

--- a/lexicon/providers/digitalocean.py
+++ b/lexicon/providers/digitalocean.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -35,7 +38,7 @@ class Provider(BaseProvider):
 
         payload = self._post('/domains/{0}/records'.format(self.domain_id), record)
 
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -73,7 +76,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'].lower() == content.lower()]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -89,7 +92,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/domains/{0}/records/{1}'.format(self.domain_id, identifier), data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -97,7 +100,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -105,7 +108,7 @@ class Provider(BaseProvider):
         payload = self._delete('/domains/{0}/records/{1}'.format(self.domain_id, identifier))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: {0}', True)
         return True
 
 

--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -64,7 +67,7 @@ class Provider(BaseProvider):
         else:
             payload = self._post('{0}/zones/{1}/records'.format(self.account_id, self.options.get('domain')), record)
 
-        print('create_record: {0}'.format('id' in payload))
+        logger.debug('create_record: %s', 'id' in payload)
         return 'id' in payload
 
     # List all records. Return an empty list if no records found
@@ -91,7 +94,7 @@ class Provider(BaseProvider):
                 processed_record['priority'] = record['priority']
             records.append(processed_record)
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -112,7 +115,7 @@ class Provider(BaseProvider):
 
         payload = self._patch('/{0}/zones/{1}/records/{2}'.format(self.account_id, self.options.get('domain'), identifier), data)
 
-        print('update_record: {0}'.format('id' in payload))
+        logger.debug('update_record: %s', 'id' in payload)
         return 'id' in payload
 
     # Delete an existing record.
@@ -127,7 +130,7 @@ class Provider(BaseProvider):
         payload = self._delete('/{0}/zones/{1}/records/{2}'.format(self.account_id, self.options.get('domain'), identifier))
 
         # is always True at this point; if a non 2xx response is returned, an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: {0}', True)
         return True
 
 

--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify api token used to authenticate")

--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -1,14 +1,18 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-from builtins import bytes
-import requests
-import json
-import datetime
-import locale
+from __future__ import print_function
+
 import contextlib
-from hashlib import sha1
+import datetime
 import hmac
+import json
+import locale
+from hashlib import sha1
+
+import requests
+from builtins import bytes
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify username used to authenticate")

--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -6,12 +6,15 @@ import datetime
 import hmac
 import json
 import locale
+import logging
 from hashlib import sha1
 
 import requests
 from builtins import bytes
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -51,7 +54,7 @@ class Provider(BaseProvider):
                 payload = {}
 
                 # http 400 is ok here, because the record probably already exists
-        print('create_record: {0}'.format('name' in payload))
+        logger.debug('create_record: %s', 'name' in payload)
         return 'name' in payload
 
     # List all records. Return an empty list if no records found
@@ -78,7 +81,7 @@ class Provider(BaseProvider):
             processed_record = self._clean_TXT_record(processed_record)
             records.append(processed_record)
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -98,7 +101,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/dns/managed/{0}/records/{1}'.format(self.domain_id, identifier), data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: {0}', True)
         return True
 
     # Delete an existing record.
@@ -106,7 +109,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -114,7 +117,7 @@ class Provider(BaseProvider):
         payload = self._delete('/dns/managed/{0}/records/{1}'.format(self.domain_id, identifier))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/dnspark.py
+++ b/lexicon/providers/dnspark.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify api key used to authenticate")

--- a/lexicon/providers/dnspark.py
+++ b/lexicon/providers/dnspark.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -45,7 +48,7 @@ class Provider(BaseProvider):
                 payload = {}
             raise e
                 # http 400 is ok here, because the record probably already exists
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -73,7 +76,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -91,7 +94,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/dns/{0}'.format(identifier), data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -99,7 +102,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -107,7 +110,7 @@ class Provider(BaseProvider):
         payload = self._delete('/dns/{0}'.format(identifier))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/dnspod.py
+++ b/lexicon/providers/dnspod.py
@@ -2,9 +2,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -45,7 +49,7 @@ class Provider(BaseProvider):
         if payload['status']['code'] not in ['1', '31']:
             raise Exception(payload['status']['message'])
 
-        print('create_record: {0}'.format(payload['status']['code'] == '1'))
+        logger.debug('create_record: %s', payload['status']['code'] == '1')
         return payload['status']['code'] == '1'
 
     # List all records. Return an empty list if no records found
@@ -55,7 +59,7 @@ class Provider(BaseProvider):
         filter = {}
 
         payload = self._post('/Record.List', {'domain':self.options['domain']})
-        print(payload)
+        logger.debug('payload: %s', payload)
         records = []
         for record in payload['records']:
             processed_record = {
@@ -75,7 +79,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -91,13 +95,13 @@ class Provider(BaseProvider):
         }
         if self.options.get('ttl'):
             data['ttl'] = self.options.get('ttl')
-        print(data)
+        logger.debug('data: %s', data)
         payload = self._post('/Record.Modify', data)
-        print(payload)
+        logger.debug('payload: %s', payload)
         if payload['status']['code'] != '1':
             raise Exception(payload['status']['message'])
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -105,7 +109,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -116,7 +120,7 @@ class Provider(BaseProvider):
             raise Exception(payload['status']['message'])
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/dnspod.py
+++ b/lexicon/providers/dnspod.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
+from __future__ import print_function
+
 import requests
-import json
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify api id used to authenticate")

--- a/lexicon/providers/easydns.py
+++ b/lexicon/providers/easydns.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -48,7 +51,7 @@ class Provider(BaseProvider):
                 payload = {}
 
                 # http 400 is ok here, because the record probably already exists
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -76,7 +79,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -94,7 +97,7 @@ class Provider(BaseProvider):
 
         payload = self._post('/zones/records/{0}'.format(identifier), data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -102,7 +105,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -110,7 +113,7 @@ class Provider(BaseProvider):
         payload = self._delete('/zones/records/{0}/{1}'.format(self.domain_id, identifier))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/easydns.py
+++ b/lexicon/providers/easydns.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify username used to authenticate")

--- a/lexicon/providers/glesys.py
+++ b/lexicon/providers/glesys.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify username (CL12345)")

--- a/lexicon/providers/luadns.py
+++ b/lexicon/providers/luadns.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify email address used to authenticate")

--- a/lexicon/providers/luadns.py
+++ b/lexicon/providers/luadns.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -35,7 +38,7 @@ class Provider(BaseProvider):
     def create_record(self, type, name, content):
         payload = self._post('/zones/{0}/records'.format(self.domain_id), {'type': type, 'name': self._fqdn_name(name), 'content': content, 'ttl': self.options['ttl']})
 
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -62,7 +65,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -81,7 +84,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/zones/{0}/records/{1}'.format(self.domain_id, identifier), data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -89,14 +92,14 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
                 raise Exception('Record identifier could not be found.')
         payload = self._delete('/zones/{0}/records/{1}'.format(self.domain_id, identifier))
 
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/memset.py
+++ b/lexicon/providers/memset.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -37,7 +40,7 @@ class Provider(BaseProvider):
             payload = self._get('/dns.zone_record_create', data)
             if payload['id']:
                 self._get('/dns.reload')
-                print('create_record: {0}'.format(payload['id']))
+                logger.debug('create_record: %s', payload['id'])
                 return payload['id']
 
     # List all records. Return an empty list if no records found
@@ -71,7 +74,7 @@ class Provider(BaseProvider):
                 else:
                     records.append(processed_record)
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -97,7 +100,7 @@ class Provider(BaseProvider):
         payload = self._get('/dns.zone_record_update', data)
         if payload['id']:
             self._get('/dns.reload')
-            print('update_record: {0}'.format(payload['id']))
+            logger.debug('update_record: %s', payload['id'])
             return payload['id']
 
     # Delete an existing record.
@@ -112,7 +115,7 @@ class Provider(BaseProvider):
         payload = self._get('/dns.zone_record_delete', {'id': identifier})
         if payload['id']:
             self._get('/dns.reload')
-            print('delete_record: {0}'.format(payload['id']))
+            logger.debug('delete_record: %s', payload['id'])
             return payload['id']
 
     # Helpers

--- a/lexicon/providers/memset.py
+++ b/lexicon/providers/memset.py
@@ -1,8 +1,11 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
 
 
 def ProviderParser(subparser):

--- a/lexicon/providers/namesilo.py
+++ b/lexicon/providers/namesilo.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
 from xml.etree import ElementTree
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -36,7 +39,7 @@ class Provider(BaseProvider):
         if self.options.get('ttl'):
             record['rrttl'] = self.options.get('ttl')
         payload = self._get('/dnsAddRecord', record)
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -64,7 +67,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -85,7 +88,7 @@ class Provider(BaseProvider):
 
         payload = self._get('/dnsUpdateRecord', data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -96,7 +99,7 @@ class Provider(BaseProvider):
         }
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 data['rrid'] = records[0]['id']
             else:
@@ -105,7 +108,7 @@ class Provider(BaseProvider):
             data['rrid'] = identifier
         payload = self._get('/dnsDeleteRecord', data)
 
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/namesilo.py
+++ b/lexicon/providers/namesilo.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 from xml.etree import ElementTree
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify key used authenticate")

--- a/lexicon/providers/nsone.py
+++ b/lexicon/providers/nsone.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify token used authenticate to DNS provider")

--- a/lexicon/providers/nsone.py
+++ b/lexicon/providers/nsone.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -46,7 +49,7 @@ class Provider(BaseProvider):
                 payload = {}
 
                 # http 400 is ok here, because the record probably already exists
-        print('create_record: {0}'.format('id' in payload))
+        logger.debug('create_record: %s', 'id' in payload)
         return 'id' in payload
 
     # List all records. Return an empty list if no records found
@@ -75,7 +78,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -99,7 +102,7 @@ class Provider(BaseProvider):
             self.create_record(type or old_record['type'], name or old_record['domain'], content or old_record['answers'][0]['answer'][0])
             self.delete_record(identifier)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -107,7 +110,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -115,7 +118,7 @@ class Provider(BaseProvider):
         payload = self._delete('/zones/{0}'.format(identifier))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/pointhq.py
+++ b/lexicon/providers/pointhq.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -32,7 +35,7 @@ class Provider(BaseProvider):
     def create_record(self, type, name, content):
         payload = self._post('/zones/{0}/records'.format(self.domain_id), {'zone_record': {'record_type': type, 'name': self._relative_name(name), 'data': content}})
 
-        print('create_record: {0}'.format(payload['zone_record']))
+        logger.debug('create_record: %s', payload['zone_record'])
         return bool(payload['zone_record'])
 
     # List all records. Return an empty list if no records found
@@ -61,7 +64,7 @@ class Provider(BaseProvider):
             processed_record = self._clean_TXT_record(processed_record)
             records.append(processed_record)
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -77,7 +80,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/zones/{0}/records/{1}'.format(self.domain_id, identifier), {'zone_record': data})
 
-        print('update_record: {0}'.format(payload))
+        logger.debug('update_record: %s', payload)
         return bool(payload['zone_record'])
 
     # Delete an existing record.
@@ -85,14 +88,14 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
                 raise Exception('Record identifier could not be found.')
         payload = self._delete('/zones/{0}/records/{1}'.format(self.domain_id, identifier))
 
-        print('delete_record: {0}'.format(payload['zone_record']['status']))
+        logger.debug('delete_record: %s', payload['zone_record']['status'])
         return payload['zone_record']['status'] == 'OK'
 
 

--- a/lexicon/providers/pointhq.py
+++ b/lexicon/providers/pointhq.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify email address used to authenticate")

--- a/lexicon/providers/powerdns.py
+++ b/lexicon/providers/powerdns.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 # Lexicon PowerDNS Provider
 #

--- a/lexicon/providers/powerdns.py
+++ b/lexicon/providers/powerdns.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 # Lexicon PowerDNS Provider
@@ -93,7 +96,7 @@ class Provider(BaseProvider):
                             'content': self._unclean_content(rrset['type'], record['content']),
                             'id': self._make_identifier(rrset['type'], rrset['name'], record['content'])
                         })
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     def _clean_content(self, type, content):
@@ -143,7 +146,7 @@ class Provider(BaseProvider):
         update_data['name'] = self._fqdn_name(update_data['name'])
 
         request = {'rrsets': [update_data]}
-        print(request)
+        logger.debug('request: %s', request)
 
         self._patch('/zones/' + self.options['domain'], data=request)
         self._zone_data = None
@@ -153,7 +156,7 @@ class Provider(BaseProvider):
         if identifier is not None:
             type, name, content = self._parse_identifier(identifier)
 
-        print("delete {} {} {}".format(type, name, content))
+        logger.debug("delete %s %s %s", type, name, content)
         if type is None or name is None:
             raise Exception("Must specify at least both type and name")
 
@@ -176,7 +179,7 @@ class Provider(BaseProvider):
         update_data['records'] = new_records
 
         request = {'rrsets': [update_data]}
-        print(request)
+        logger.debug('request: %s', request)
 
         self._patch('/zones/' + self.options['domain'], data=request)
         self._zone_data = None
@@ -200,6 +203,6 @@ class Provider(BaseProvider):
                                  'X-API-Key': self.api_key,
                                  'Content-Type': 'application/json'
                              })
-        print("response: " + r.text)
+        logger.debug('response: %s', r.text)
         r.raise_for_status()
         return r

--- a/lexicon/providers/rage4.py
+++ b/lexicon/providers/rage4.py
@@ -2,10 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -47,7 +50,7 @@ class Provider(BaseProvider):
                 payload = {}
 
                 # http 400 is ok here, because the record probably already exists
-        print('create_record: {0}'.format(payload['status']))
+        logger.debug('create_record: %s', payload['status'])
         return payload['status']
 
     # List all records. Return an empty list if no records found
@@ -73,7 +76,7 @@ class Provider(BaseProvider):
             records.append(processed_record)
 
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -94,7 +97,7 @@ class Provider(BaseProvider):
 
         payload = self._put('/updaterecord/', {}, data)
 
-        print('update_record: {0}'.format(payload['status']))
+        logger.debug('update_record: %s', payload['status'])
         return payload['status']
 
     # Delete an existing record.
@@ -102,7 +105,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -110,7 +113,7 @@ class Provider(BaseProvider):
         payload = self._post('/deleterecord/', {'id': identifier})
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(payload['status']))
+        logger.debug('delete_record: %s', payload['status'])
         return payload['status']
 
 

--- a/lexicon/providers/rage4.py
+++ b/lexicon/providers/rage4.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-username", help="specify email address used to authenticate")

--- a/lexicon/providers/route53.py
+++ b/lexicon/providers/route53.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+
 from .base import Provider as BaseProvider
 
 try:
@@ -9,6 +11,8 @@ try:
     import botocore #optional dep
 except ImportError:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -128,7 +132,7 @@ class Provider(BaseProvider):
             )
             return True
         except botocore.exceptions.ClientError as e:
-            print(e.message)
+            logger.debug(e.message, exc_info=True)
 
     def create_record(self, type, name, content):
         """Create a record in the hosted zone."""
@@ -161,12 +165,12 @@ class Provider(BaseProvider):
                                   in record['ResourceRecords']]
             if content is not None and content not in record_content:
                 continue
-            print(record)
+            logger.debug('record: %s', record)
             records.append({
                 'type': record['Type'],
                 'name': self._full_name(record['Name']),
                 'ttl': record.get('TTL', None),
                 'content': record_content[0] if len(record_content) == 1 else record_content,
             })
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records

--- a/lexicon/providers/route53.py
+++ b/lexicon/providers/route53.py
@@ -1,14 +1,14 @@
 """Provide support to Lexicon for AWS Route 53 DNS changes."""
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
+
 from .base import Provider as BaseProvider
+
 try:
     import boto3 #optional dep
     import botocore #optional dep
 except ImportError:
     pass
-
-
 
 
 def ProviderParser(subparser):

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -1,13 +1,13 @@
-from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
+
 from .base import Provider as BaseProvider
-from ..common.options_handler import SafeOptions
+
 try:
     from transip.service.dns import DnsEntry
     from transip.service.domain import DomainService
 except ImportError:
     pass
-
 
 
 def ProviderParser(subparser):

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+
 from .base import Provider as BaseProvider
 
 try:
@@ -8,6 +10,8 @@ try:
     from transip.service.domain import DomainService
 except ImportError:
     pass
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -62,7 +66,7 @@ class Provider(BaseProvider):
         records = self.client.get_info(self.options.get('domain')).dnsEntries
         if self._filter_records(records, type, name, content):
             # Nothing to do, record already exists
-            print('create_record: already exists')
+            logger.debug('create_record: already exists')
             return True
 
         records.append(DnsEntry(**{
@@ -74,7 +78,7 @@ class Provider(BaseProvider):
 
         self.client.set_dns_entries(self.options.get('domain'), records)
         status = len(self.list_records(type, name, content, show_output=False)) >= 1
-        print("create_record: {0}".format(status))
+        logger.debug('create_record: %s', status)
         return status
 
     # List all records. Return an empty list if no records found
@@ -90,7 +94,7 @@ class Provider(BaseProvider):
         )
 
         if show_output:
-            print('list_records: {0}'.format(records))
+            logger.debug('list_records: %s', records)
         return records
 
     # Update a record. Identifier must be specified.
@@ -113,7 +117,7 @@ class Provider(BaseProvider):
 
         self.client.set_dns_entries(self.options.get('domain'), self._convert_records_back(all_records))
         status = len(self.list_records(type, name, content, show_output=False)) >= 1
-        print("update_record: {0}".format(status))
+        logger.debug('update_record: %s', status)
         return status
 
     # Delete an existing record.
@@ -131,7 +135,7 @@ class Provider(BaseProvider):
 
         self.client.set_dns_entries(self.options.get('domain'), self._convert_records_back(all_records))
         status = len(self.list_records(type, name, content, show_output=False)) == 0
-        print("delete_record: {0}".format(status))
+        logger.debug('delete_record: %s', status)
         return status
 
     def _full_name(self, record_name):

--- a/lexicon/providers/vultr.py
+++ b/lexicon/providers/vultr.py
@@ -1,8 +1,10 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
+from __future__ import print_function
+
 import requests
-import json
+
+from .base import Provider as BaseProvider
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify token used authenticate to DNS provider")

--- a/lexicon/providers/vultr.py
+++ b/lexicon/providers/vultr.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
+import logging
+
 import requests
 
 from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
 
 
 def ProviderParser(subparser):
@@ -42,7 +46,7 @@ class Provider(BaseProvider):
             record['ttl'] = self.options.get('ttl')
         payload = self._post('/dns/create_record', record)
 
-        print('create_record: {0}'.format(True))
+        logger.debug('create_record: %s', True)
         return True
 
     # List all records. Return an empty list if no records found
@@ -71,7 +75,7 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Create or update a record.
@@ -94,7 +98,7 @@ class Provider(BaseProvider):
 
         payload = self._post('/dns/update_record', data)
 
-        print('update_record: {0}'.format(True))
+        logger.debug('update_record: %s', True)
         return True
 
     # Delete an existing record.
@@ -102,7 +106,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -115,7 +119,7 @@ class Provider(BaseProvider):
         payload = self._post('/dns/delete_record', data)
 
         # is always True at this point, if a non 200 response is returned an error is raised.
-        print('delete_record: {0}'.format(True))
+        logger.debug('delete_record: %s', True)
         return True
 
 

--- a/lexicon/providers/yandex.py
+++ b/lexicon/providers/yandex.py
@@ -1,8 +1,12 @@
-from __future__ import print_function
 from __future__ import absolute_import
-from .base import Provider as BaseProvider
-import requests
+from __future__ import print_function
+
 import json
+
+import requests
+
+from .base import Provider as BaseProvider
+
 __author__ = 'Aliaksandr Kharkevich'
 __license__ = 'MIT'
 __contact__ = 'https://github.com/kharkevich'

--- a/lexicon/providers/yandex.py
+++ b/lexicon/providers/yandex.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import json
+import logging
 
 import requests
 
@@ -10,6 +11,9 @@ from .base import Provider as BaseProvider
 __author__ = 'Aliaksandr Kharkevich'
 __license__ = 'MIT'
 __contact__ = 'https://github.com/kharkevich'
+
+logger = logging.getLogger(__name__)
+
 
 def ProviderParser(subparser):
     subparser.add_argument("--auth-token", help="specify PDD token (https://tech.yandex.com/domain/doc/concepts/access-docpage/)")
@@ -74,14 +78,14 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'].lower() == content.lower()]
 
-        print('list_records: {0}'.format(records))
+        logger.debug('list_records: %s', records)
         return records
 
     # Just update existing record. Domain ID (domain) and Identifier (record_id) is mandatory
     def update_record(self, identifier, type=None, name=None, content=None):
 
         if not identifier:
-            print('Domain ID (domain) and Identifier (record_id) is mandatory parameters for this case')
+            logger.debug('Domain ID (domain) and Identifier (record_id) is mandatory parameters for this case')
             return False
         
         data = ''
@@ -101,7 +105,7 @@ class Provider(BaseProvider):
     def delete_record(self, identifier=None, type=None, name=None, content=None):
         if not identifier:
             records = self.list_records(type, name, content)
-            print(records)
+            logger.debug('records: %s', records)
             if len(records) == 1:
                 identifier = records[0]['id']
             else:
@@ -137,8 +141,8 @@ class Provider(BaseProvider):
 
     def _check_exitcode(self, payload, title):
         if payload['success'] == 'ok':
-            print('{0}: {1}'.format(title, payload['success']))
+            logger.debug('%s: %s', title, payload['success'])
             return True
         else:
-            print('{0}: {1}'.format(title, payload['error']))
+            logger.debug('%s: %s', title, payload['error'])
             return False


### PR DESCRIPTION
Currently, the convention for providers is to invoke print directly. For code using Lexicon as a library, it would be helpful to use a pattern that allows for suppressing or redirecting output (e.g., to a log file).

This change replaces all print to DEBUG-level calls to the Python logging standard module.

Resolves #124