### PR TITLE
Improve error handling in dnsmadeeasy provider

### DIFF
--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -23,9 +23,15 @@ class Provider(BaseProvider):
 
     def authenticate(self):
 
-        payload = self._get('/dns/managed/name', {'domainname': self.options['domain']})
+        try:
+            payload = self._get('/dns/managed/name', {'domainname': self.options['domain']})
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                payload = {}
+            else:
+                raise e
 
-        if not payload['id']:
+        if not payload or not payload['id']:
             raise Exception('No domain found')
 
         self.domain_id = payload['id']


### PR DESCRIPTION
Currently, `dnsmadeeasy.Provider.authenticate` will raise an `HTTPError` when the supplied domain is not associated with the account as a result of the DNS Made Easy API throwing a 404 in at least some cases.

This change ensures the expected Exception (clearly stating "No domain found") is thrown in this case.