### PR TITLE
Fix logging TypeError

### DIFF
--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -130,7 +130,7 @@ class Provider(BaseProvider):
         payload = self._delete('/{0}/zones/{1}/records/{2}'.format(self.account_id, self.options.get('domain'), identifier))
 
         # is always True at this point; if a non 2xx response is returned, an error is raised.
-        logger.debug('delete_record: {0}', True)
+        logger.debug('delete_record: True')
         return True
 
 


### PR DESCRIPTION
Without this change, I get tracebacks like:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/handlers.py", line 76, in emit
    if self.shouldRollover(record):
  File "/usr/lib/python2.7/logging/handlers.py", line 156, in shouldRollover
    msg = "%s\n" % self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```
when using dnssimple.