### PR TITLE
Remove unecessary handling of delegated domain

### DIFF
--- a/lexicon/client.py
+++ b/lexicon/client.py
@@ -16,7 +16,14 @@ class Client(object):
 
         if cli_options.get('delegated'):
             # handle delegated domain
-            cli_options['domain'] = cli_options.get('delegated').rstrip('.')
+            delegated = cli_options.get('delegated').rstrip('.')
+            if delegated != cli_options.get('domain'):
+                # convert to relative name
+                if delegated.endswith(cli_options.get('domain')):
+                    delegated = delegated[:-len(cli_options.get('domain'))]
+                    delegated = delegated.rstrip('.')
+                # update domain
+                cli_options['domain'] = '{0}.{1}'.format(delegated, cli_options.get('domain'))
 
         self.action = cli_options.get('action')
         self.provider_name = cli_options.get('provider_name')

--- a/lexicon/client.py
+++ b/lexicon/client.py
@@ -16,13 +16,7 @@ class Client(object):
 
         if cli_options.get('delegated'):
             # handle delegated domain
-            delegated = cli_options.get('delegated').rstrip('.')
-            # convert to relative name
-            if delegated.endswith(cli_options.get('domain')):
-                delegated = delegated[:-len(cli_options.get('domain'))]
-                delegated = delegated.rstrip('.')
-            # update domain
-            cli_options['domain'] = '{0}.{1}'.format(delegated, cli_options.get('domain'))
+            cli_options['domain'] = cli_options.get('delegated').rstrip('.')
 
         self.action = cli_options.get('action')
         self.provider_name = cli_options.get('provider_name')
@@ -57,3 +51,4 @@ class Client(object):
             raise AttributeError('domain')
         if not options.get('type'):
             raise AttributeError('type')
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ def test_Client_init_with_delegated_domain_name():
     options = {
         'provider_name':'base',
         'action': 'list',
-        'domain': 'example.com',
+        'domain': 'www.sub.example.com',
         'delegated': 'sub',
         'type': 'TXT'
     }
@@ -48,7 +48,7 @@ def test_Client_init_with_delegated_domain_fqdn():
     options = {
         'provider_name':'base',
         'action': 'list',
-        'domain': 'example.com',
+        'domain': 'www.sub.example.com',
         'delegated': 'sub.example.com',
         'type': 'TXT'
     }
@@ -59,6 +59,20 @@ def test_Client_init_with_delegated_domain_fqdn():
     assert client.options['domain'] == "sub.example.com"
     assert client.options['type'] == options['type']
 
+def test_Client_init_with_same_delegated_domain_fqdn():
+    options = {
+        'provider_name':'base',
+        'action': 'list',
+        'domain': 'www.example.com',
+        'delegated': 'example.com',
+        'type': 'TXT'
+    }
+    client = lexicon.client.Client(options)
+
+    assert client.provider_name == options['provider_name']
+    assert client.action == options['action']
+    assert client.options['domain'] == "example.com"
+    assert client.options['type'] == options['type']
 
 def test_Client_init_when_missing_provider_should_fail():
     options = {


### PR DESCRIPTION
Currently the client performs an unnecessary step when dealing with delegated domains. It splits the **domain** from the **delegated domain** and then joins these again. This causes an issue if `cli_options.get('delegated') == cli_options.get('domain')`, as then domain provided is then prepended with a leading `.` which causes a failure later when the provider (e.g. route53) tries to find a matching domain.

For example, when `domain = 'www.example.com'` and `delegated = example.com` then _currently_ the resultant domain is `.example.com` as shown by running the following snippet of code:

```python
import tldextract
cli_options = {'domain': 'www.example.com', 'delegated': 'example.com'}

domain_parts = tldextract.extract(cli_options.get('domain'))
cli_options['domain'] = '{0}.{1}'.format(domain_parts.domain, domain_parts.suffix)

delegated = cli_options.get('delegated').rstrip('.')
if delegated.endswith(cli_options.get('domain')):
    delegated = delegated[:-len(cli_options.get('domain'))]
    delegated = delegated.rstrip('.')

cli_options['domain'] = '{0}.{1}'.format(delegated, cli_options.get('domain'))

print(cli_options['domain'])
```
