### PR TITLE
Add startup_hook() to the dehydrated example

### DIFF
--- a/examples/dehydrated.default.sh
+++ b/examples/dehydrated.default.sh
@@ -101,4 +101,11 @@ exit_hook() {
   :
 }
 
+startup_hook() {
+  # This hook is called before the dehydrated command to do some initial tasks
+  # (e.g. starting a webserver).
+
+  :
+}
+
 HANDLER=$1; shift; $HANDLER "$@"


### PR DESCRIPTION
The change in https://github.com/lukas2511/dehydrated/commit/60583d3ef9a62712851adeb488c7b454dc36ccbf adds `startup_hook` to the hook interface of dehydrated.

The example script in `lexicon` breaks when used with the current `dehydrated` master.

This change adds an empty `startup_hook()` function to satisfy the new interface.