### PR TITLE
Add SoftLayer provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The current supported providers are:
 - PointHQ ([docs](https://pointhq.com/api/docs))
 - PowerDNS ([docs](https://doc.powerdns.com/md/httpapi/api_spec/))
 - Rage4 ([docs](https://gbshouse.uservoice.com/knowledgebase/articles/109834-rage4-dns-developers-api))
+- SoftLayer ([docs](https://sldn.softlayer.com/article/REST#HTTP_Request_Types))
 - Transip ([docs](https://www.transip.nl/transip/api/))
 - Yandex ([docs](https://tech.yandex.com/domain/doc/reference/dns-add-docpage/))
 - Vultr ([docs](https://www.vultr.com/api/))
@@ -65,7 +66,6 @@ Potential providers are as follows. If you would like to contribute one, please 
 - ~~OnApp DNS ([docs](https://docs.onapp.com/display/3api/DNS+Zones))~~ <sub>Unable to test, requires paid account</sub>
 - Rackspace ([docs](https://developer.rackspace.com/docs/cloud-dns/v1/developer-guide/))
 - RFC2136 ([docs](https://en.wikipedia.org/wiki/Dynamic_DNS))
-- SoftLayer ([docs](https://sldn.softlayer.com/article/REST#HTTP_Request_Types))
 - ~~UltraDNS ([docs](https://restapi.ultradns.com/v1/docs))~~ <sub>Unable to test, requires paid account</sub>
 - ~~WorldWideDns ([docs](https://www.worldwidedns.net/dns_api_protocol.asp))~~ <sub>Unable to test, requires paid account</sub>
 - ~~Zerigo ([docs](https://www.zerigo.com/managed-dns/rest-api))~~ <sub>Unable to test, requires paid account</sub>

--- a/lexicon/providers/softlayer.py
+++ b/lexicon/providers/softlayer.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+
+from .base import Provider as BaseProvider
+
+try:
+    import SoftLayer
+except ImportError:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-username", help="specify username used to authenticate")
+    subparser.add_argument("--auth-api-key", help="specify API private key to authenticate")
+
+class Provider(BaseProvider):
+
+    def __init__(self, options, engine_overrides=None):
+        super(Provider, self).__init__(options, engine_overrides)
+        self.domain_id = None
+
+        username = self.options.get('auth_username')
+        api_key = self.options.get('auth_api_key')
+
+        if not username or not api_key:
+            raise Exception("No username and/or api key was specified")
+
+        sl_client = SoftLayer.create_client_from_env(username=username, api_key=api_key)
+        self.sl_dns = SoftLayer.managers.dns.DNSManager(sl_client)
+
+
+    # Authenticate against provider,
+    # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
+    # Should throw an error if authentication fails for any reason, of if the domain does not exist.
+    def authenticate(self):
+        domain = self.options.get('domain')
+
+        payload = self.sl_dns.resolve_ids(domain)
+
+        if len(payload) < 1:
+            raise Exception('No domain found')
+        if len(payload) > 1:
+            raise Exception('Too many domains found. This should not happen')
+
+        logger.debug('domain id: %s', payload[0])
+        self.domain_id = payload[0]
+
+
+    # Create record. If record already exists with the same content, do nothing
+    def create_record(self, type, name, content):
+        records = self.list_records(type,name,content)
+        if len(records) > 0:
+            # Nothing to do, record already exists
+            logger.debug('create_record: already exists')
+            return True
+
+        name = self._relative_name(name)
+        ttl = self.options.get('ttl')
+        payload = self.sl_dns.create_record(self.domain_id,name,type,content,ttl)
+
+        logger.debug('create_record: %s', payload)
+        return True
+
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        ttl=None
+        if name:
+            name = self._relative_name(name)
+
+        payload = self.sl_dns.get_records(self.domain_id,ttl,content,name,type)
+
+        records = []
+        for record in payload:
+            processed_record = {
+                'type': record['type'].upper(),
+                'name': self._full_name(record['host']),
+                'ttl': record['ttl'],
+                'content': record['data'],
+                'id': record['id']
+            }
+            records.append(processed_record)
+
+        logger.debug('list_records: %s', records)
+        return records
+
+
+    # Update a record.
+    # If an identifier is specified, use it, otherwise do a lookup using type and name.
+    def update_record(self, identifier=None, type=None, name=None, content=None):
+        if not identifier:
+            records = self.list_records(type, name)
+            if len(records) == 1:
+                identifier = records[0]['id']
+            else:
+                raise Exception('Record identifier could not be found.')
+
+        record = { 'id': identifier }
+        if type:
+            record['type'] = type
+        if name:
+            record['host'] = self._relative_name(name)
+        if content:
+            record['data'] = content
+        if self.options.get('ttl'):
+            record['ttl'] = self.options.get('ttl')
+
+        payload = self.sl_dns.edit_record(record)
+
+        logger.debug('update_record: %s', payload)
+        return True
+
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    # If an identifier is specified, use it, otherwise do a lookup using type, name and content.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        if not identifier:
+            records = self.list_records(type, name, content)
+            if len(records) == 1:
+                identifier = records[0]['id']
+            else:
+                raise Exception('Record identifier could not be found.')
+
+        payload = self.sl_dns.delete_record(identifier)
+
+        logger.debug('delete_record: %s', payload)
+        return True
+

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -16,4 +16,5 @@
 
 --process-dependency-links
 .[route53]
+.[softlayer]
 .[transip]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
     # added to optional-requirements.txt as well.
     extras_require={
         'route53': ['boto3'],
+        'softlayer': ['SoftLayer'],
         'transip': ['transip>=0.3.0']
     },
 

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071502</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-16T03:06:20-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:10 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,122 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= thisisadomainidonotown.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['870']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:10 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,471 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071502</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-16T03:06:20-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:10 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= 127.0.0.1</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= localhost</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= a</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1601']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:11 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>127.0.0.1</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>localhost</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>A</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['949']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>127.0.0.1</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>localhost</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479063</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>A</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071503</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:11-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1761']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:11 GMT']
+      ntcoent-length: ['1761']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,471 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071503</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:11-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:12 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= docs.example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= docs</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= cname</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1607']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:12 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>docs.example.com</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>docs</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>CNAME</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['955']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>docs.example.com</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>docs</string>\n    </value>\n   </member>\n   <member>\n
+        \   <name>id</name>\n    <value>\n     <int>80479065</int>\n    </value>\n
+        \  </member>\n   <member>\n    <name>minimum</name>\n    <value>\n     <string/>\n
+        \   </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>CNAME</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071504</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:13-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1767']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:13 GMT']
+      ntcoent-length: ['1767']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,471 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071504</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:13-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:13 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= _acme-challenge.fqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1619']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:13 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>_acme-challenge.fqdn</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['967']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>_acme-challenge.fqdn</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479067</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071505</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:14-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1779']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:14 GMT']
+      ntcoent-length: ['1779']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,471 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071505</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:14-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:15 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= _acme-challenge.full</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1619']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:15 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>_acme-challenge.full</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['967']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>_acme-challenge.full</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479069</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071506</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:15-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1779']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:15 GMT']
+      ntcoent-length: ['1779']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,471 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071506</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:15-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:16 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= _acme-challenge.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1619']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:16 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>_acme-challenge.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['967']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>_acme-challenge.test</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479071</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071507</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:17-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1779']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:17 GMT']
+      ntcoent-length: ['1779']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,953 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071507</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:17-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:17 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfilt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:17 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>delete.testfilt</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['962']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>delete.testfilt</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479073</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071508</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:18-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1774']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:18 GMT']
+      ntcoent-length: ['1774']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfilt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>delete.testfilt</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479073</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1442']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:18 GMT']
+      ntcoent-length: ['1442']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>deleteObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479073</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['713']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:19 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfilt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1451']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:19 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,953 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071509</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:19-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:19 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:20 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>delete.testfqdn</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['962']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>delete.testfqdn</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479075</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071510</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:20-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1774']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:20 GMT']
+      ntcoent-length: ['1774']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>delete.testfqdn</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479075</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1442']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:21 GMT']
+      ntcoent-length: ['1442']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>deleteObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479075</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['713']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:21 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1451']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:21 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,953 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071511</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:21-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:22 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfull</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:22 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>delete.testfull</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['962']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>delete.testfull</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479077</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071512</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:23-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1774']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:23 GMT']
+      ntcoent-length: ['1774']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfull</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>delete.testfull</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479077</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1442']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:23 GMT']
+      ntcoent-length: ['1442']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>deleteObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479077</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['713']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:23 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testfull</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1451']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:24 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,935 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071513</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:24-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:25 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testid</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1612']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:26 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>delete.testid</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['960']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>delete.testid</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479079</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071514</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:26-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1772']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:26 GMT']
+      ntcoent-length: ['1772']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testid</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1449']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>delete.testid</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479079</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1440']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:27 GMT']
+      ntcoent-length: ['1440']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>deleteObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479079</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['713']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:27 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= delete.testid</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1449']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:28 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,662 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071515</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:27-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:28 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= ttlshouldbe3600</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= ttl.fqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1608']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:28 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>ttlshouldbe3600</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>ttl.fqdn</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['956']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>ttlshouldbe3600</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>ttl.fqdn</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479081</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071516</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:29-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1768']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:29 GMT']
+      ntcoent-length: ['1768']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= ttl.fqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1444']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>ttlshouldbe3600</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>ttl.fqdn</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80479081</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>3600</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>txt</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1436']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:29 GMT']
+      ntcoent-length: ['1436']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,662 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071516</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:29-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:30 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.fqdntest</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:30 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>random.fqdntest</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['962']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>random.fqdntest</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479083</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071517</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:31-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1774']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:31 GMT']
+      ntcoent-length: ['1774']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.fqdntest</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1451']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.fqdntest</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479083</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1442']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:31 GMT']
+      ntcoent-length: ['1442']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,662 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071517</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:31-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:31 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.fulltest</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1614']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:32 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>random.fulltest</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['962']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>random.fulltest</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479085</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071518</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:32-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1774']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:32 GMT']
+      ntcoent-length: ['1774']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.fulltest</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1451']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.fulltest</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479085</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1442']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:33 GMT']
+      ntcoent-length: ['1442']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,662 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071518</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:32-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:33 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1610']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:33 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>random.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['958']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>random.test</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479087</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071519</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:34-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1770']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:34 GMT']
+      ntcoent-length: ['1770']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= random.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1447']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.test</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80479087</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>3600</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>txt</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1438']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:34 GMT']
+      ntcoent-length: ['1438']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,562 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071519</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:34-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:35 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1053']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.fqdntest</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479083</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.fulltest</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479085</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>random.test</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80479087</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>3600</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>txt</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n    <value>\n     <struct>\n      <member>\n       <name>data</name>\n
+        \      <value>\n        <string>ttlshouldbe3600</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>domainId</name>\n       <value>\n
+        \       <int>2140781</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>expire</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>host</name>\n       <value>\n
+        \       <string>ttl.fqdn</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>80479081</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>minimum</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>txt</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>challengetoken</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>_acme-challenge.fqdn</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80479067</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>txt</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>challengetoken</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>_acme-challenge.full</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80479069</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>txt</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>challengetoken</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>_acme-challenge.test</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80479071</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>txt</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>ns1.softlayer.com.</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <int>1728000</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>host</name>\n       <value>\n        <string>@</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80478913</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <int>43200</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <int>7200</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>responsiblePerson</name>\n       <value>\n
+        \       <string>support.softlayer.com.</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>retry</name>\n       <value>\n        <int>600</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>86400</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>soa</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>ns1.softlayer.com.</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>@</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80478915</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>86400</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>ns</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>data</name>\n       <value>\n        <string>ns2.softlayer.com.</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>@</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80478917</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>86400</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>ns</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n    <value>\n     <struct>\n      <member>\n       <name>data</name>\n
+        \      <value>\n        <string>mail.example.com.</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>domainId</name>\n       <value>\n
+        \       <int>2140781</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>expire</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>host</name>\n       <value>\n
+        \       <string>@</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>80478927</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>minimum</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <int>10</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>refresh</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>86400</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>mx</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n    <value>\n     <struct>\n      <member>\n       <name>data</name>\n
+        \      <value>\n        <string>docs.example.com</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>domainId</name>\n       <value>\n
+        \       <int>2140781</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>expire</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>host</name>\n       <value>\n
+        \       <string>docs</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>80479065</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>minimum</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>cname</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>127.0.0.1</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>@</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80478911</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>86400</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>a</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>data</name>\n       <value>\n        <string>127.0.0.1</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>ftp</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80478925</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>86400</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>a</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n    <value>\n     <struct>\n      <member>\n       <name>data</name>\n
+        \      <value>\n        <string>127.0.0.1</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>localhost</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80479063</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>3600</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>a</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>127.0.0.1</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>mail</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80478919</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>86400</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>a</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>127.0.0.1</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>webmail</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>id</name>\n
+        \      <value>\n        <int>80478921</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>minimum</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>mxPriority</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>refresh</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>retry</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>ttl</name>\n
+        \      <value>\n        <int>86400</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>type</name>\n       <value>\n        <string>a</string>\n
+        \      </value>\n      </member>\n     </struct>\n    </value>\n    <value>\n
+        \    <struct>\n      <member>\n       <name>data</name>\n       <value>\n
+        \       <string>127.0.0.1</string>\n       </value>\n      </member>\n      <member>\n
+        \      <name>domainId</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>expire</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>host</name>\n       <value>\n        <string>www</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80478923</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>86400</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>a</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['23682']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:35 GMT']
+      server: [Apache]
+      softlayer-total-items: ['18']
+      transfer-encoding: [chunked]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,809 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071519</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:34-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:36 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1608']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:36 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>orig.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['956']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>orig.test</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479089</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071520</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:37-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1768']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:36 GMT']
+      ntcoent-length: ['1768']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1445']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>orig.test</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>80479089</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>minimum</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>mxPriority</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>refresh</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>retry</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>ttl</name>\n       <value>\n        <int>3600</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>type</name>\n       <value>\n
+        \       <string>txt</string>\n       </value>\n      </member>\n     </struct>\n
+        \   </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1436']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:37 GMT']
+      ntcoent-length: ['1436']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>editObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479089</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>updated.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479089</int></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1138']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:37 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,809 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071521</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:37-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:38 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.nameonly.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1617']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:38 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>orig.nameonly.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['965']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>orig.nameonly.test</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479091</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071522</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:39-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1777']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:39 GMT']
+      ntcoent-length: ['1777']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.nameonly.test</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1454']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>orig.nameonly.test</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479091</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1445']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:39 GMT']
+      ntcoent-length: ['1445']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>editObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479091</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>updated</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>orig.nameonly.test</string></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479091</int></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1137']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:39 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,809 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071523</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:40-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:40 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.testfqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1612']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:40 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>orig.testfqdn</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['960']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>orig.testfqdn</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479093</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071524</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:41-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1772']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:41 GMT']
+      ntcoent-length: ['1772']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.testfqdn</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1449']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>orig.testfqdn</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479093</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1440']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:41 GMT']
+      ntcoent-length: ['1440']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>editObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479093</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>updated.testfqdn</string></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479093</int></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1142']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:42 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/softlayer/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,809 @@
+interactions:
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getDomains</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_AccountObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>domains</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>name</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= example.com</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['856']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Account
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>id</name>\n       <value>\n        <int>2140781</int>\n       </value>\n
+        \     </member>\n      <member>\n       <name>name</name>\n       <value>\n
+        \       <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071525</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:42-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['690']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:42 GMT']
+      ntcoent-length: ['690']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= challengetoken</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.testfull</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1612']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data/>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['126']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:43 GMT']
+      ntcoent-length: ['126']
+      server: [Apache]
+      softlayer-total-items: ['0']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>createObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>orig.testfull</string></value>
+
+      </member>
+
+      <member>
+
+      <name>domainId</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['960']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <struct>\n   <member>\n    <name>data</name>\n    <value>\n     <string>challengetoken</string>\n
+        \   </value>\n   </member>\n   <member>\n    <name>domainId</name>\n    <value>\n
+        \    <int>2140781</int>\n    </value>\n   </member>\n   <member>\n    <name>expire</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>host</name>\n
+        \   <value>\n     <string>orig.testfull</string>\n    </value>\n   </member>\n
+        \  <member>\n    <name>id</name>\n    <value>\n     <int>80479095</int>\n
+        \   </value>\n   </member>\n   <member>\n    <name>minimum</name>\n    <value>\n
+        \    <string/>\n    </value>\n   </member>\n   <member>\n    <name>mxPriority</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>refresh</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>retry</name>\n
+        \   <value>\n     <string/>\n    </value>\n   </member>\n   <member>\n    <name>ttl</name>\n
+        \   <value>\n     <int>3600</int>\n    </value>\n   </member>\n   <member>\n
+        \   <name>type</name>\n    <value>\n     <string>TXT</string>\n    </value>\n
+        \  </member>\n   <member>\n    <name>domain</name>\n    <value>\n     <struct>\n
+        \     <member>\n       <name>id</name>\n       <value>\n        <int>2140781</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>name</name>\n
+        \      <value>\n        <string>example.com</string>\n       </value>\n      </member>\n
+        \     <member>\n       <name>serial</name>\n       <value>\n        <int>2017071526</int>\n
+        \      </value>\n      </member>\n      <member>\n       <name>updateDate</name>\n
+        \      <value>\n        <string>2017-07-15T22:18:43-05:00</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </member>\n  </struct>\n
+        </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1772']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:43 GMT']
+      ntcoent-length: ['1772']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>getResourceRecords</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>2140781</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_Dns_DomainObjectFilter</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>resourceRecords</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>host</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= orig.testfull</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>operation</name>
+
+      <value><string>_= txt</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>SoftLayer_ObjectMask</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>mask</name>
+
+      <value><string>mask[id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson]</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1449']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <array>\n   <data>\n    <value>\n     <struct>\n      <member>\n
+        \      <name>data</name>\n       <value>\n        <string>challengetoken</string>\n
+        \      </value>\n      </member>\n      <member>\n       <name>domainId</name>\n
+        \      <value>\n        <int>2140781</int>\n       </value>\n      </member>\n
+        \     <member>\n       <name>expire</name>\n       <value>\n        <string/>\n
+        \      </value>\n      </member>\n      <member>\n       <name>host</name>\n
+        \      <value>\n        <string>orig.testfull</string>\n       </value>\n
+        \     </member>\n      <member>\n       <name>id</name>\n       <value>\n
+        \       <int>80479095</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>minimum</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>mxPriority</name>\n       <value>\n
+        \       <string/>\n       </value>\n      </member>\n      <member>\n       <name>refresh</name>\n
+        \      <value>\n        <string/>\n       </value>\n      </member>\n      <member>\n
+        \      <name>retry</name>\n       <value>\n        <string/>\n       </value>\n
+        \     </member>\n      <member>\n       <name>ttl</name>\n       <value>\n
+        \       <int>3600</int>\n       </value>\n      </member>\n      <member>\n
+        \      <name>type</name>\n       <value>\n        <string>txt</string>\n       </value>\n
+        \     </member>\n     </struct>\n    </value>\n   </data>\n  </array>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['1440']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:44 GMT']
+      ntcoent-length: ['1440']
+      server: [Apache]
+      softlayer-total-items: ['1']
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0''?>
+
+      <methodCall>
+
+      <methodName>editObject</methodName>
+
+      <params>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>headers</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>SoftLayer_Dns_Domain_ResourceRecordInitParameters</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479095</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      <member>
+
+      <name>authenticate</name>
+
+      <value><struct>
+
+      <member>
+
+      <name>username</name>
+
+      <value><string>placeholder_auth_username</string></value>
+
+      </member>
+
+      <member>
+
+      <name>apiKey</name>
+
+      <value><string>placeholder_auth_api_key</string></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      <param>
+
+      <value><struct>
+
+      <member>
+
+      <name>data</name>
+
+      <value><string>challengetoken</string></value>
+
+      </member>
+
+      <member>
+
+      <name>host</name>
+
+      <value><string>updated.testfull</string></value>
+
+      </member>
+
+      <member>
+
+      <name>type</name>
+
+      <value><string>TXT</string></value>
+
+      </member>
+
+      <member>
+
+      <name>id</name>
+
+      <value><int>80479095</int></value>
+
+      </member>
+
+      <member>
+
+      <name>ttl</name>
+
+      <value><int>3600</int></value>
+
+      </member>
+
+      </struct></value>
+
+      </param>
+
+      </params>
+
+      </methodCall>
+
+'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate, compress']
+      Connection: [keep-alive]
+      Content-Length: ['1142']
+      Content-Type: [application/xml]
+      User-Agent: [softlayer-python/v4.1.1]
+    method: POST
+    uri: https://api.softlayer.com/xmlrpc/v3.1/SoftLayer_Dns_Domain_ResourceRecord
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<params>\n<param>\n
+        <value>\n  <boolean>1</boolean>\n </value>\n</param>\n</params>\n"}
+    headers:
+      cache-control: [private]
+      connection: [close]
+      content-length: ['117']
+      content-type: [text/xml]
+      date: ['Sun, 16 Jul 2017 03:18:44 GMT']
+      ntcoent-length: ['117']
+      server: [Apache]
+      vary: [Accept-Encoding]
+      x-frame-options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_softlayer.py
+++ b/tests/providers/test_softlayer.py
@@ -1,0 +1,24 @@
+# Test for one implementation of the interface
+from lexicon.providers.softlayer import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from define_tests.TheTests
+class SoftLayerProviderTests(TestCase, IntegrationTests):
+
+    Provider = Provider
+    provider_name = 'softlayer'
+    domain = 'example.com'
+
+    # SoftLayer does not provide a sandbox API; actual credentials are required
+    # Keeping this here for when fixtures need to be regenerated
+    #def _test_options(self):
+    #    options = super(SoftLayerProviderTests, self)._test_options()
+    #    options.update({
+    #        'auth_username': 'foo',
+    #        'auth_api_key': 'bar'
+    #        })
+    #    return options


### PR DESCRIPTION
Adds support for SoftLayer.

I had a bit of trouble building the test fixtures - I thought (based on CONTRIBUTING.md) that I could set the appropriate env vars, and it would use those credentials while running the tests and building the fixtures. But that didn't seem to work for me. I ended up putting the credentials directly into the test file, running the tests to build the fixtures, and then removed the credentials from the test file and the generated fixtures.

(Separately, I also have access to accounts at Linode and at Hover, and could contribute providers for those as well. But I'd like to make sure I've got this one done correctly before working on those.)