### PR TITLE
Add implementation for ClouDNS provider

### DIFF
--- a/lexicon/providers/cloudns.py
+++ b/lexicon/providers/cloudns.py
@@ -1,0 +1,172 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+import requests
+
+from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
+
+
+def ProviderParser(subparser):
+    identity_group = subparser.add_mutually_exclusive_group()
+    identity_group.add_argument("--auth-id", help="specify user id used to authenticate")
+    identity_group.add_argument("--auth-subid", help="specify subuser id used to authenticate")
+    identity_group.add_argument("--auth-subuser", help="specify subuser name used to authenticate")
+    subparser.add_argument("--auth-password", help="specify password used to authenticate")
+    subparser.add_argument("--weight", help="specify the SRV record weight")
+    subparser.add_argument("--port", help="specify the SRV record port")
+
+
+class Provider(BaseProvider):
+    def __init__(self, options, engine_overrides=None):
+        super(Provider, self).__init__(options, engine_overrides)
+        self.domain_id = None
+        self.api_endpoint = self.engine_overrides.get('api_endpoint', 'https://api.cloudns.net')
+
+    def authenticate(self):
+        payload = self._get('/dns/get-zone-info.json', {'domain-name': self.options['domain']})
+        self.domain_id = payload['name']
+        logger.debug('authenticate: %s', payload)
+
+    def create_record(self, type, name, content):
+        # Skip execution if such a record already exists
+        existing_records = self.list_records(type, name, content)
+        if len(existing_records) > 0:
+            return True
+
+        # Build parameters for adding a new record
+        params = {
+            'domain-name': self.domain_id,
+            'record-type': type,
+            'host': self._relative_name(name),
+            'record': content
+        }
+        if self.options['ttl']:
+            params['ttl'] = self.options['ttl']
+        if self.options['priority']:
+            params['priority'] = self.options['priority']
+        if self.options['weight']:
+            params['weight'] = self.options['weight']
+        if self.options['port']:
+            params['port'] = self.options['port']
+
+        # Add new record by calling the ClouDNS API
+        payload = self._post('/dns/add-record.json', params)
+        logger.debug('create_record: %s', payload)
+
+        # Error handling is already covered by self._request
+        return True
+
+    def list_records(self, type=None, name=None, content=None):
+        # Build parameters to make use of the built-in API filtering
+        params = {'domain-name': self.domain_id}
+        if type:
+            params['type'] = type
+        if name:
+            params['host'] = self._relative_name(name)
+
+        # Fetch and parse all records for the given zone
+        payload = self._get('/dns/records.json', params)
+        payload = payload if not isinstance(payload, list) else {}
+        records = []
+        for record in payload.values():
+            records.append({
+                'type': record['type'],
+                'name': self._full_name(record['host']),
+                'ttl': record['ttl'],
+                'content': record['record'],
+                'id': record['id']
+            })
+
+        # Filter by content manually as API does not support that
+        if content:
+            records = [record for record in records if record['content'] == content]
+
+        # Print records as debug output and return them
+        logger.debug('list_records: %s', records)
+        return records
+
+    def update_record(self, identifier, type=None, name=None, content=None):
+        # Try to find record if no identifier was specified
+        if not identifier:
+            identifier = self._find_record_identifier(type, name, None)
+
+        # Build parameters for updating an existing record
+        params = {'domain-name': self.domain_id, 'record-id': identifier}
+        if name:
+            params['host'] = self._relative_name(name)
+        if content:
+            params['record'] = content
+        if self.options.get('ttl'):
+            params['ttl'] = self.options.get('ttl')
+        if self.options['priority']:
+            params['priority'] = self.options['priority']
+        if self.options['weight']:
+            params['weight'] = self.options['weight']
+        if self.options['port']:
+            params['port'] = self.options['port']
+
+        # Update existing record by calling the ClouDNS API
+        payload = self._post('/dns/mod-record.json', params)
+        logger.debug('update_record: %s', payload)
+
+        # Error handling is already covered by self._request
+        return True
+
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        # Try to find record if no identifier was specified
+        if not identifier:
+            identifier = self._find_record_identifier(type, name, content)
+
+        # Delete existing record by calling the ClouDNS API
+        payload = self._post('/dns/delete-record.json', {'domain-name': self.domain_id, 'record-id': identifier})
+        logger.debug('delete_record: %s', payload)
+
+        # Error handling is already covered by self._request
+        return True
+
+    def _build_authentication_data(self):
+        if not self.options['auth_password']:
+            raise Exception('No valid authentication data passed, expected: auth-password')
+
+        if self.options['auth_id']:
+            return {'auth-id': self.options['auth_id'], 'auth-password': self.options['auth_password']}
+        elif self.options['auth_subid']:
+            return {'sub-auth-id': self.options['auth_subid'], 'auth-password': self.options['auth_password']}
+        elif self.options['auth_subuser']:
+            return {'sub-auth-user': self.options['auth_subuser'], 'auth-password': self.options['auth_password']}
+        else:
+            raise Exception('No valid authentication data passed, expected: auth-id, auth-subid, auth-subuser')
+
+    def _find_record_identifier(self, type, name, content):
+        records = self.list_records(type, name, content)
+        logger.debug('records: %s', records)
+        if len(records) == 1:
+            return records[0]['id']
+        else:
+            raise Exception('Record identifier could not be found.')
+
+    def _request(self, action='GET', url='/', data=None, query_params=None):
+        # Set default values for missing arguments
+        data = data if data else {}
+        query_params = query_params if query_params else {}
+
+        # Merge authentication data into request
+        if action == 'GET':
+            query_params.update(self._build_authentication_data())
+        else:
+            data.update(self._build_authentication_data())
+
+        # Fire request against ClouDNS API and parse result as JSON
+        r = requests.request(action, self.api_endpoint + url, params=query_params, data=data)
+        r.raise_for_status()
+        payload = r.json()
+
+        # Check ClouDNS specific status code and description
+        if 'status' in payload and 'statusDescription' in payload and payload['status'] != 'Success':
+            raise Exception('ClouDNS API request has failed: ' + payload['statusDescription'])
+
+        # Return payload
+        return payload

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:30 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,24 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=thisisadomainidonotown.com
+  response:
+    body: {string: '{"status":"Failed","statusDescription":"Missing domain-name"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['61']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:30 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:30 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=localhost&type=A
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:31 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=A&host=localhost&record=127.0.0.1&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['204']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776944}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:31 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:31 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=docs&type=CNAME
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:31 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=CNAME&host=docs&record=docs.example.com&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['210']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776945}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:31 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:32 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=_acme-challenge.fqdn&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:32 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=_acme-challenge.fqdn&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['222']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776946}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:32 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:32 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=_acme-challenge.full&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:33 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=_acme-challenge.full&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['222']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776947}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:33 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,71 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:33 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=_acme-challenge.test&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:33 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=_acme-challenge.test&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['222']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776948}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:33 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:34 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfilt&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:34 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=delete.testfilt&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776949}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:34 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfilt&type=TXT
+  response:
+    body: {string: '{"30776949":{"id":"30776949","type":"TXT","host":"delete.testfilt","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:34 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776949
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/delete-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was deleted
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['79']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:35 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfilt&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:35 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:35 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfqdn&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:35 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=delete.testfqdn&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776950}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:35 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfqdn&type=TXT
+  response:
+    body: {string: '{"30776950":{"id":"30776950","type":"TXT","host":"delete.testfqdn","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:36 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776950
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/delete-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was deleted
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['79']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:36 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfqdn&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:36 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:36 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfull&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:37 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=delete.testfull&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776952}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:37 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfull&type=TXT
+  response:
+    body: {string: '{"30776952":{"id":"30776952","type":"TXT","host":"delete.testfull","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:37 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776952
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/delete-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was deleted
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['79']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:37 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testfull&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:37 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:38 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testid&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:38 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=delete.testid&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['215']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776953}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:38 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testid&type=TXT
+  response:
+    body: {string: '{"30776953":{"id":"30776953","type":"TXT","host":"delete.testid","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:38 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776953
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['90']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/delete-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was deleted
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['79']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:39 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=delete.testid&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:39 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:39 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=ttl.fqdn&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:39 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=ttl.fqdn&record=ttlshouldbe3600&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['211']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776954}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:39 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=ttl.fqdn&type=TXT
+  response:
+    body: {string: '{"30776954":{"id":"30776954","type":"TXT","host":"ttl.fqdn","record":"ttlshouldbe3600","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:40 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:40 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.fqdntest&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:40 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=random.fqdntest&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776956}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:40 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.fqdntest&type=TXT
+  response:
+    body: {string: '{"30776956":{"id":"30776956","type":"TXT","host":"random.fqdntest","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:41 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:41 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.fulltest&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:41 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=random.fulltest&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776957}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:41 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.fulltest&type=TXT
+  response:
+    body: {string: '{"30776957":{"id":"30776957","type":"TXT","host":"random.fulltest","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:41 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:42 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.test&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:42 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=random.test&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['213']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776958}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:42 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=random.test&type=TXT
+  response:
+    body: {string: '{"30776958":{"id":"30776958","type":"TXT","host":"random.test","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['114']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:42 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:43 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com
+  response:
+    body: {string: '{"30776945":{"id":"30776945","type":"CNAME","host":"docs","record":"docs.example.com","ttl":"3600","status":1},"30776944":{"id":"30776944","type":"A","host":"localhost","record":"127.0.0.1","dynamicurl_status":0,"ttl":"3600","status":1},"30776956":{"id":"30776956","type":"TXT","host":"random.fqdntest","record":"challengetoken","ttl":"3600","status":1},"30776957":{"id":"30776957","type":"TXT","host":"random.fulltest","record":"challengetoken","ttl":"3600","status":1},"30776958":{"id":"30776958","type":"TXT","host":"random.test","record":"challengetoken","ttl":"3600","status":1},"30776954":{"id":"30776954","type":"TXT","host":"ttl.fqdn","record":"ttlshouldbe3600","ttl":"3600","status":1},"30776946":{"id":"30776946","type":"TXT","host":"_acme-challenge.fqdn","record":"challengetoken","ttl":"3600","status":1},"30776947":{"id":"30776947","type":"TXT","host":"_acme-challenge.full","record":"challengetoken","ttl":"3600","status":1},"30776948":{"id":"30776948","type":"TXT","host":"_acme-challenge.test","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['1061']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:43 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:43 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.test&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:43 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=orig.test&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['211']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776959}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:43 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.test&type=TXT
+  response:
+    body: {string: '{"30776959":{"id":"30776959","type":"TXT","host":"orig.test","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:44 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776959&host=updated.test&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['217']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/mod-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was modified
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:44 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:44 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.nameonly.test&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:44 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=orig.nameonly.test&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['220']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776960}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:45 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.nameonly.test&type=TXT
+  response:
+    body: {string: '{"30776960":{"id":"30776960","type":"TXT","host":"orig.nameonly.test","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:45 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776960&host=orig.nameonly.test&record=updated&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['216']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/mod-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was modified
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:45 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:45 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.testfqdn&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:45 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=orig.testfqdn&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['215']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776961}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:46 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.testfqdn&type=TXT
+  response:
+    body: {string: '{"30776961":{"id":"30776961","type":"TXT","host":"orig.testfqdn","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:46 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776961&host=updated.testfqdn&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['221']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/mod-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was modified
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:46 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/cloudns/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/get-zone-info.json?domain-name=api-example.com
+  response:
+    body: {string: '{"name":"api-example.com","type":"master","zone":"domain","status":"1"}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:46 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.testfull&type=TXT
+  response:
+    body: {string: '[]'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:47 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-type=TXT&host=orig.testfull&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['215']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/add-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was added
+        successfully.","data":{"id":30776962}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['100']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:47 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.3]
+    method: GET
+    uri: https://api.cloudns.net/dns/records.json?domain-name=api-example.com&host=orig.testfull&type=TXT
+  response:
+    body: {string: '{"30776962":{"id":"30776962","type":"TXT","host":"orig.testfull","record":"challengetoken","ttl":"3600","status":1}}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:47 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: domain-name=api-example.com&record-id=30776962&host=updated.testfull&record=challengetoken&ttl=3600&priority=placeholder_priority&weight=placeholder_weight&port=placeholder_port
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['221']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.3]
+    method: POST
+    uri: https://api.cloudns.net/dns/mod-record.json
+  response:
+    body: {string: '{"status":"Success","statusDescription":"The record was modified
+        successfully."}'}
+    headers:
+      Connection: [Keep-Alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      Date: ['Fri, 04 Aug 2017 21:44:47 GMT']
+      Keep-Alive: [timeout=5]
+      Server: [Apache]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_cloudns.py
+++ b/tests/providers/test_cloudns.py
@@ -1,0 +1,26 @@
+# Test for one implementation of the interface
+from lexicon.providers.cloudns import Provider
+from lexicon.common.options_handler import env_auth_options
+from integration_tests import IntegrationTests
+from unittest import TestCase
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from define_tests.TheTests
+class CloudnsProviderTests(TestCase, IntegrationTests):
+    Provider = Provider
+    provider_name = 'cloudns'
+    domain = 'api-example.com'
+
+    def _filter_query_parameters(self):
+        return ['auth-id', 'sub-auth-id', 'sub-auth-user', 'auth-password']
+
+    def _filter_post_data_parameters(self):
+        return ['auth-id', 'sub-auth-id', 'sub-auth-user', 'auth-password']
+
+    # Override _test_options to call env_auth_options and then import auth config from env variables
+    def _test_options(self):
+        cmd_options = super(CloudnsProviderTests, self)._test_options()
+        cmd_options.update(env_auth_options(self.provider_name))
+        return cmd_options


### PR DESCRIPTION
This pull request adds a working implementation of the ClouDNS provider to Lexicon. Recorded cassettes for the test suite are included, as accessing the API requires a paid account.