### PR TITLE
Filter on Private Zone when searching hosted zone

### DIFF
--- a/tests/providers/test_route53.py
+++ b/tests/providers/test_route53.py
@@ -2,8 +2,7 @@
 import unittest
 import pytest
 from lexicon.providers.route53 import Provider
-from integration_tests import IntegrationTests
-
+from integration_tests import IntegrationTests, provider_vcr
 
 class Route53ProviderTests(unittest.TestCase, IntegrationTests):
     """Route53 Proivder Tests."""
@@ -15,6 +14,22 @@ class Route53ProviderTests(unittest.TestCase, IntegrationTests):
     def _filter_headers(self):
         """Sensitive headers to be filtered."""
         return ['Authorization']
+
+    def test_Provider_authenticate_private_zone_only(self):
+        with provider_vcr.use_cassette(super(Route53ProviderTests, self)._cassette_path('IntegrationTests/test_Provider_authenticate.yaml'), filter_headers=super(Route53ProviderTests, self)._filter_headers(), filter_query_parameters=super(Route53ProviderTests, self)._filter_query_parameters(), filter_post_data_parameters=super(Route53ProviderTests, self)._filter_post_data_parameters()):
+            options = super(Route53ProviderTests, self)._test_options()
+            options['private_zone'] = 'true'
+            provider = self.Provider(options, super(Route53ProviderTests, self)._test_engine_overrides())
+            with pytest.raises(Exception):
+                provider.authenticate()
+
+    def test_Provider_authenticate_private_zone_false(self):
+        with provider_vcr.use_cassette(super(Route53ProviderTests, self)._cassette_path('IntegrationTests/test_Provider_authenticate.yaml'), filter_headers=super(Route53ProviderTests, self)._filter_headers(), filter_query_parameters=super(Route53ProviderTests, self)._filter_query_parameters(), filter_post_data_parameters=super(Route53ProviderTests, self)._filter_post_data_parameters()):
+            options = super(Route53ProviderTests, self)._test_options()
+            options['private_zone'] = 'false'
+            provider = self.Provider(options, super(Route53ProviderTests, self)._test_engine_overrides())
+            provider.authenticate()
+            assert provider.domain_id is not None
 
     @pytest.mark.skip(reason="route 53 dns records don't have ids")
     def test_Provider_when_calling_delete_record_by_identifier_should_remove_record(self):


### PR DESCRIPTION
Add "--private-zone" argument to only search for Private Hosted Zones when true and Public Hosted zones when false.

Resolves #142 