### PR TITLE
Update README.md to add ClouDNS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The current supported providers are:
 
 - AWS Route53 ([docs](https://docs.aws.amazon.com/Route53/latest/APIReference/Welcome.html))
 - Cloudflare ([docs](https://api.cloudflare.com/#endpoints))
+- ClouDNS ([docs](https://www.cloudns.net/wiki/article/56/))
 - CloudXNS ([docs](https://www.cloudxns.net/Support/lists/cid/17.html))
 - DigitalOcean ([docs](https://developers.digitalocean.com/documentation/v2/#create-a-new-domain))
 - DNSimple ([docs](https://developer.dnsimple.com/))
@@ -51,7 +52,6 @@ Potential providers are as follows. If you would like to contribute one, please 
 - AuroraDNS ([docs](https://www.pcextreme.com/aurora/dns))
 - AHNames ([docs](https://ahnames.com/en/resellers?tab=2))
 - ~~BuddyDNS ([docs](https://www.buddyns.com/support/api/v2/))~~
-- ~~ClouDNS ([docs](https://www.cloudns.net/wiki/article/56/))~~ <sub>Unable to test, requires paid account</sub>
 - ~~DurableDNS ([docs](https://durabledns.com/wiki/doku.php/ddns))~~ <sub>Can't set TXT records</sub>
 - ~~Dyn ([docs](https://help.dyn.com/dns-api-knowledge-base/))~~ <sub>Unable to test, requires paid account</sub>
 - ~~EntryDNS ([docs](https://entrydns.net/help))~~ <sub>Unable to test, requires paid account</sub>


### PR DESCRIPTION
Latest version of Lexicon (v2.1.11) provides ClouDNS API support. The proposed change for README.md reflects that.

Regards,
Adrien Ferrand