### PR TITLE
Rackspace provider handle duplicate record on create

### DIFF
--- a/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -108,7 +108,7 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Auth-Token: [!!python/unicode 'placeholder_auth_token']
     method: GET
-    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?content=challengetoken&per_page=100&type=TXT&name=delete.testfilt.capsulecd.com
+    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?data=challengetoken&per_page=100&type=TXT&name=delete.testfilt.capsulecd.com
   response:
     body: {string: !!python/unicode '{"records":[{"name":"delete.testfilt.capsulecd.com","id":"TXT-1614049","type":"TXT","data":"challengetoken","ttl":3600,"updated":"2018-01-31T15:02:36.000+0000","created":"2018-01-31T15:02:36.000+0000"}]}'}
     headers:

--- a/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -112,7 +112,7 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Auth-Token: [!!python/unicode 'placeholder_auth_token']
     method: GET
-    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?content=challengetoken&per_page=100&type=TXT&name=delete.testfqdn.capsulecd.com
+    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?data=challengetoken&per_page=100&type=TXT&name=delete.testfqdn.capsulecd.com
   response:
     body: {string: !!python/unicode '{"records":[{"name":"delete.testfqdn.capsulecd.com","id":"TXT-1614052","type":"TXT","data":"challengetoken","ttl":3600,"updated":"2018-01-31T15:02:40.000+0000","created":"2018-01-31T15:02:40.000+0000"}]}'}
     headers:

--- a/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -111,7 +111,7 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Auth-Token: [!!python/unicode 'placeholder_auth_token']
     method: GET
-    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?content=challengetoken&per_page=100&type=TXT&name=delete.testfull.capsulecd.com
+    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?data=challengetoken&per_page=100&type=TXT&name=delete.testfull.capsulecd.com
   response:
     body: {string: !!python/unicode '{"records":[{"name":"delete.testfull.capsulecd.com","id":"TXT-1614055","type":"TXT","data":"challengetoken","ttl":3600,"updated":"2018-01-31T15:02:44.000+0000","created":"2018-01-31T15:02:44.000+0000"}]}'}
     headers:

--- a/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/rackspace/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -114,7 +114,7 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Auth-Token: [!!python/unicode 'placeholder_auth_token']
     method: GET
-    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?content=updated&per_page=100&type=TXT&name=orig.nameonly.test.capsulecd.com
+    uri: https://dns.api.rackspacecloud.com/v1.0/placeholder_auth_account/domains/1234567/records?data=updated&per_page=100&type=TXT&name=orig.nameonly.test.capsulecd.com
   response:
     body: {string: !!python/unicode '{"records":[{"name":"orig.nameonly.test.capsulecd.com","id":"TXT-1614076","type":"TXT","data":"challengetoken","ttl":3600,"updated":"2018-01-31T15:03:08.000+0000","created":"2018-01-31T15:03:08.000+0000"}]}'}
     headers:


### PR DESCRIPTION
I was hitting duplicate record exceptions using the lexicon hook with dehydrated to generate and verify challenge responses. This update will have it retry with an update call if the create record call fails due to there being a duplicate. There was also a bug with the content filter for list_records. Rackspace API uses a query param named data instead of content for that filter.