### PR TITLE
multiple updates for Namecheap client

### DIFF
--- a/lexicon/providers/namecheap.py
+++ b/lexicon/providers/namecheap.py
@@ -45,6 +45,20 @@ def ProviderParser(subparser):
 
 
 class Provider(BaseProvider):
+    """
+    ========================================================================
+    WARNING
+    ========================================================================
+    The Namecheap API does not add/update/delete a host but "gets" and
+    "sets" ALL hosts at once (a complete replacement). In their comments on
+    the API docs (https://www.namecheap.com/support/api/methods/domains-dns/set-hosts.aspx)
+    it appears that not all host types are handled by their system.
+
+    Their API only handles `[A, AAAA, CNAME, MX, MXE, TXT, URL, URL301, FRAME]`
+
+    If you have SRV record, it may get lost. Also records configured as
+    `A + DDNS` on their control panel will be downgrated to `A` records.
+    """
 
     def __init__(self, options, engine_overrides=None):
         super(Provider, self).__init__(options, engine_overrides)
@@ -55,7 +69,7 @@ class Provider(BaseProvider):
             UserName=options.get('auth_username',''),
             ClientIP=options.get('auth_client_ip',''),
             sandbox=options.get('auth_sandbox', False),
-            debug=False
+            debug=False,
         )
         self.domain = self.options['domain']
         self.domain_id = None
@@ -228,7 +242,6 @@ class Provider(BaseProvider):
         records = self.list_records(type=type, name=name, content=content, id=identifier)
         for record in records:
             self.client.domains_dns_delHost(self.domain, self._convert_to_namecheap(record))
-        
         return True
 
     def _convert_to_namecheap(self, record):

--- a/lexicon/providers/namecheap.py
+++ b/lexicon/providers/namecheap.py
@@ -7,7 +7,8 @@ import logging
 from .base import Provider as BaseProvider
 
 try:
-    import namecheap #optional dep
+    # this module uses the optional `PyNamecheap` library from PyPi
+    import namecheap # optional dep
 except ImportError:
     pass
 
@@ -19,11 +20,18 @@ def ProviderParser(subparser):
         '--auth-token',
         help='specify api token used to authenticate'
     )
+    
+    # earlier versions of the API expected the email address here
+    # now they appear to want the username.
     subparser.add_argument(
         '--auth-username',
-        help='specify email address used to authenticate'
+        help='specify username used to authenticate'
     )
+
     # FIXME What is the client IP used for?
+    # this doesn't seem to be used for anything, but is required by their API
+    # namecheap requires API requests to come from whitelisted domains, and this
+    # is probably updated with the actual IP on their end.
     subparser.add_argument(
         '--auth-client-ip',
         help='Client IP address to send to Namecheap API calls',
@@ -34,6 +42,7 @@ def ProviderParser(subparser):
         help='Whether to use the sandbox server',
         action='store_true'
     )
+
 
 class Provider(BaseProvider):
 
@@ -52,24 +61,132 @@ class Provider(BaseProvider):
         self.domain_id = None
 
     def authenticate(self):
+        """
+        The Namecheap API is a little difficult to work with.
+        Originally this method called PyNamecheap's `domains_getList`, which is
+        connected to an API endpoint that only lists domains registered under
+        the authenticating account. However, an authenticating Namecheap user
+        may be permissioned to manage the DNS of additional domains. Namecheap's
+        API does not offer a way to list these domains.
+
+        This approach to detecting permissioned relies on some implementation
+        details of the Namecheap API and the PyNamecheap module:
+
+        * If the user does not own the domain, or is not permissioned to manage
+          it in any way, Namecheap will return an error status, which
+          PyNamecheap will instantly catch and raise.
+        * If a non-error repsonse is returned, the XML payload is analyzed.
+          If the user owns the domain it immediately returns valid. Otherwise
+          we look for "All" Modification rights, or the hosts-edit permission.
+
+        This is not feature complete and most-likely misses multiple scenarios
+        where:
+        * a user is privileged to manage the domain DNS, but via another "right"
+        * a user is privileged to manage the domain, but DNS is not configured
+
+        Important Note:
+        * the Namecheap API has inconsistent use of capitalization with strings
+          and a case-insensitive match should be made. e.g. the following appear
+          in a payload: `False` and 'false', 'OK' and 'Ok'.
+
+        TODO:
+        * check payload for PremiumDNS
+          <PremiumDnsSubscription>
+            <IsActive>false</IsActive>
+          </PremiumDnsSubscription>
+        * check payload for other types of DNS
+          <DnsDetails ProviderType="FREE" IsUsingOurDNS="true" HostCount="5" EmailType="No Email Service" DynamicDNSStatus="false" IsFailover="false">
+            <Nameserver>dns1.registrar-servers.com</Nameserver>
+            <Nameserver>dns2.registrar-servers.com</Nameserver>
+          </DnsDetails>
+        """
+        extra_payload = {'DomainName': self.domain, }
+
         try:
-            domain_names = [x['Name'] for x in self.client.domains_getList()]
-        except namecheap.ApiError:
-            raise Exception('Authentication failed')
-        if self.domain not in domain_names:
+            xml = self.client._call('namecheap.domains.getInfo', extra_payload)
+        except namecheap.ApiError as err:
+            # this will happen if there is an API connection error
+            # OR if the user is not permissioned to manage this domain
+            # OR the API request came from a not whitelisted IP
+            # we should print the error, so people know how to correct it.
+            raise Exception('Authentication failed: `%s`' % str(err))
+
+        xpath = './/{%(ns)s}CommandResponse/{%(ns)s}DomainGetInfoResult' % {'ns': namecheap.NAMESPACE}
+        domain_info = xml.find(xpath)
+
+        def _check_hosts_permission():
+            # this shouldn't happen
+            if domain_info is None:
+                return False
+
+            # do they own the domain?
+            if domain_info.attrib['IsOwner'].lower() == 'true':
+                return True
+
+            # look for rights
+            xpath_alt = './/{%(ns)s}CommandResponse/{%(ns)s}DomainGetInfoResult/{%(ns)s}Modificationrights' % {'ns': namecheap.NAMESPACE}
+            rights_info = xml.find(xpath_alt)
+            if rights_info is None:
+                return False
+
+            # all rights
+            if rights_info.attrib['All'].lower() == 'true':
+                return True
+
+            for right in rights_info.getchildren():
+                if right.attrib['Type'].lower() == 'hosts':
+                    if right.text.lower() == 'ok':
+                        return True
+                    else:
+                        # we're only looking at hosts, so we can exit now
+                        return False
+
+            return None
+
+        permissioned = _check_hosts_permission()
+        if not permissioned:
             raise Exception('The domain {} is not controlled by this Namecheap '
                             'account'.format(self.domain))
+
         # FIXME What is this for?
         self.domain_id = self.domain
 
+    def option_ttl(self):
+        """
+        via https://www.namecheap.com/support/api/methods/domains-dns/set-hosts.aspx
+            Time to live for all record types.
+            Possible values: any value between 60 to 60000
+            Default Value: 1800
+        if a TTL is submitted on the commandline:
+            this will parse and validate it
+        if no TTL is submitted:
+            it will be ignored allowing the server-side default
+        """
+        ttl_submitted = self.options.get('ttl', None)
+        if ttl_submitted is not None:
+            # if the ttl isn't an Int within a valid range,
+            # an exception will be raised
+            ttl_submitted = int(ttl_submitted)
+            if ttl_submitted > 60000:
+                raise ValueError("Namecheap TTL must between 60 and 60000")
+            elif ttl_submitted < 60:
+                raise ValueError("Namecheap TTL must between 60 and 60000")
+            # cast this to a string
+            ttl_submitted = "%s" % ttl_submitted
+        return ttl_submitted
+        
     # Create record. If record already exists with the same content, do nothing
     def create_record(self, type, name, content):
         record = {
             # required
             'Type': type,
             'Name': self._relative_name(name),
-            'Address': content
+            'Address': content,
         }
+        # inject the ttl if specified
+        option_ttl = self.option_ttl()
+        if option_ttl:
+            record['TTL'] = option_ttl
         # logger.debug('create_record: %s', 'id' in payload)
         # return 'id' in payload
         self.client.domains_dns_addHost(self.domain, record)
@@ -80,8 +197,6 @@ class Provider(BaseProvider):
     # If possible filter during the query, otherwise filter after response is
     # received.
     def list_records(self, type=None, name=None, content=None, id=None):
-
-
         records = []
         raw_records = self.client.domains_dns_getHosts(self.domain)
         for record in raw_records:

--- a/lexicon/providers/namecheap.py
+++ b/lexicon/providers/namecheap.py
@@ -167,27 +167,22 @@ class Provider(BaseProvider):
 
     def option_ttl(self):
         """
+        Parse the `options` for a TTL.
+        Used as a distinct function for documentation.
         via https://www.namecheap.com/support/api/methods/domains-dns/set-hosts.aspx
             Time to live for all record types.
             Possible values: any value between 60 to 60000
             Default Value: 1800
         if a TTL is submitted on the commandline:
-            this will parse and validate it
+            this will parse, but not validate it
         if no TTL is submitted:
-            it will be ignored allowing the server-side default
+            it will be ignored, allowing the server-side default
+        Please note:
+            Namecheap appears to have an internal cache on records; even with a
+            short TTL of 60 seconds, it may take 120 seconds for their DNS to
+            propagate.
         """
-        ttl_submitted = self.options.get('ttl', None)
-        if ttl_submitted is not None:
-            # if the ttl isn't an Int within a valid range,
-            # an exception will be raised
-            ttl_submitted = int(ttl_submitted)
-            if ttl_submitted > 60000:
-                raise ValueError("Namecheap TTL must between 60 and 60000")
-            elif ttl_submitted < 60:
-                raise ValueError("Namecheap TTL must between 60 and 60000")
-            # cast this to a string
-            ttl_submitted = "%s" % ttl_submitted
-        return ttl_submitted
+        return self.options.get('ttl', None)
         
     # Create record. If record already exists with the same content, do nothing
     def create_record(self, type, name, content):

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.02</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.244</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1052']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:20 GMT']
+      date: ['Mon, 26 Mar 2018 17:40:59 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,67 +48,81 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.016</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:20 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"parkingpage.namecheap.com.\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"CName\
-        \ Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"\
-        505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.021</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.818</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['966']
+      content-length: ['3987']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:22 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:00 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'TTL1=1800&HostName1=www&HostName2=%40&HostName3=localhost&IsActive2=true&HostId2=505697&Address1=parkingpage.namecheap.com.&TTL2=1800&Address3=127.0.0.1&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&FriendlyName1=CName+Record&FriendlyName2=URL+Record&AssociatedAppTitle2=&AssociatedAppTitle1=&TLD=com&SLD=lexicontest&HostId1=506041&IsActive1=true&RecordType2=URL&RecordType3=A&RecordType1=CNAME&Address2=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40'
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=A&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=localhost&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=127.0.0.1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['470']
+      Content-Length: ['3326']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -114,15 +132,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.092</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.744</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:23 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:02 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.017</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.057</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:27 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:05 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,72 +48,81 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:29 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.003</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.766</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1327']
+      content-length: ['3987']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:31 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:07 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'Address3=parkingpage.namecheap.com.&MXPref3=10&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=%40&HostName5=_acme-challenge.fqdn&IsActive2=true&HostId2=506043&FriendlyName4=URL+Record&Address4=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&AssociatedAppTitle1=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=505697&IsActive4=true&TTL4=1800&RecordType4=URL&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10'
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.fqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['817']
+      Content-Length: ['3344']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -119,15 +132,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.967</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.716</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:32 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:08 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.093</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.03</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1492']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:32 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:08 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,75 +48,81 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.021</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:32 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.887</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.036</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1522']
+      content-length: ['3987']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:34 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:10 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=%40&HostName6=_acme-challenge.full&IsActive2=true&FriendlyName5=URL+Record&HostId2=506043&FriendlyName4=&Address4=challengetoken&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&SLD=lexicontest&Address5=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&IsDDNSEnabled4=false&MXPref5=10&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&AssociatedAppTitle1=&AssociatedAppTitle5=&Address6=challengetoken&IsDDNSEnabled5=false&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=505697&IsActive5=true&IsActive4=true&TTL4=1800&RecordType6=TXT&RecordType4=TXT&RecordType5=URL&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10'
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.full&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['996']
+      Content-Length: ['3344']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -122,15 +132,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.851</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.215</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:35 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:11 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.088</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.208</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:35 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:11 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,78 +48,81 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.013</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\"\
-        \ Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.959</ExecutionTime>\r\n</ApiResponse>"}
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.769</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1717']
+      content-length: ['3987']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:39 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:13 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=_acme-challenge.test&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=%40&IsActive2=true&FriendlyName5=&Address7=challengetoken&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&MXPref5=10&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&AssociatedAppTitle1=&MXPref6=10&AssociatedAppTitle5=&Address6=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&IsDDNSEnabled5=false&FriendlyName6=URL+Record&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&HostId6=505697&RecordType6=URL&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.test&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1175']
+      Content-Length: ['3344']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -125,15 +132,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.023</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.717</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:40 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:14 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -23,17 +23,17 @@ interactions:
         \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
         \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
         \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
         FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
         \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
         \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.031</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.033</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:52 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:14 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -63,28 +63,11 @@ interactions:
         false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
@@ -122,24 +105,24 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.878</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.838</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['5215']
+      content-length: ['3987']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:54 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:16 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=challengetoken1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['4527']
+      Content-Length: ['3356']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -151,13 +134,13 @@ interactions:
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
         \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
         \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.952</ExecutionTime>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.932</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:55 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:18 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -190,68 +173,84 @@ interactions:
         \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
         \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
         \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\" Name=\"_acme-challenge.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \  <host HostId=\"524168\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\" Name=\"orig.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524170\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524172\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\" Name=\"random.fqdntest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524164\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.819</ExecutionTime>\r\n</ApiResponse>"}
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524173\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\" Name=\"yyy\"\
+        \ Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.729</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['5215']
+      content-length: ['4194']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:42:57 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524160&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=URL&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524168&HostId9=524214&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524156&HostId6=524157&HostId7=524158&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName19=URL+Record&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524172&HostId13=524163&HostId10=524166&HostId11=524170&HostId16=524167&HostId17=524171&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=updated&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfull&HostName13=random.fqdntest&HostName10=orig.test&HostName11=orig.testfqdn&HostName16=updated.test&HostName17=updated.testfqdn&HostName14=random.fulltest&Address1=127.0.0.1&HostName18=updated.testfull&HostName19=yyy&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=60&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=challengetoken&Address19=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.fqdn&HostName6=_acme-challenge.full&HostName7=_acme-challenge.test&HostName8=orig.nameonly.test&HostName9=orig.nameonly.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=_acme-challenge.createrecordset&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address20=challengetoken2&AssociatedAppTitle18=&TTL19=1800&HostId14=524164&AssociatedAppTitle19=&HostId15=524165&HostId18=524173'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3557']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.063</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:20 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,355 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.037</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['1493']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:20 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\" Name=\"_acme-challenge.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524168\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524170\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524172\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524164\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524173\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\" Name=\"yyy\"\
+        \ Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.709</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4401']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:22 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524173&RecordType20=URL&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524158&HostId9=524168&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId20=524160&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524170&HostId13=524172&HostId10=524214&HostId11=524166&HostId16=524165&HostId17=524167&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfqdn&HostName13=orig.testfull&HostName10=orig.nameonly.test&HostName11=orig.test&HostName16=random.test&HostName17=updated.test&HostName14=random.fqdntest&Address1=127.0.0.1&HostName18=updated.testfqdn&HostName19=updated.testfull&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.test&HostName9=orig.nameonly.test&Address10=updated&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.noop&HostName20=yyy&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fulltest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&AssociatedAppTitle18=&TTL19=1800&HostId14=524163&AssociatedAppTitle19=&HostId15=524164&HostId18=524171'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3746']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.185</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:24 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.654</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4596']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:25 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.noop&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3935']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.07</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['558']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:26 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.949</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4596']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:41:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.028</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.19</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1492']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:40 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:27 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,81 +48,89 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:40 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.833</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.613</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:42 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:29 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&HostName8=delete.testfilt&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&RecordType8=TXT&HostId6=506046&Address8=challengetoken&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfilt&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1349']
+      Content-Length: ['3930']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -128,15 +140,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.975</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.733</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:43 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:30 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -151,42 +163,80 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506047\" Name=\"delete.testfilt\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524834\"\
+        \ Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.91</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.271</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2101']
+      content-length: ['4786']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:45 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:32 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -201,54 +251,92 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506047\" Name=\"delete.testfilt\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524834\"\
+        \ Name=\"delete.testfilt\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.792</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.653</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2102']
+      content-length: ['4786']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:46 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:33 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&HostId6=506046&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1283']
+      Content-Length: ['3861']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -258,15 +346,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.906</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.109</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:48 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:35 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -281,40 +369,77 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.706</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.749</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:49 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:36 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.083</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:58 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:44 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,81 +48,89 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.013</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:03:59 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.883</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.87</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['4595']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:00 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:46 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&HostName8=delete.testfull&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&RecordType8=TXT&HostId6=506046&Address8=challengetoken&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfull&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1349']
+      Content-Length: ['3930']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -128,15 +140,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.13</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.204</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['555']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:01 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:48 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -151,42 +163,80 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506049\" Name=\"delete.testfull\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524836\"\
+        \ Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.122</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.784</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2102']
+      content-length: ['4786']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:02 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:49 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -201,54 +251,92 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506049\" Name=\"delete.testfull\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524836\"\
+        \ Name=\"delete.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.841</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.861</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2102']
+      content-length: ['4786']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:04 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:51 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&HostId6=506046&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1283']
+      Content-Length: ['3861']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -258,15 +346,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.81</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.745</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['555']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:06 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:52 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -281,40 +369,77 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.954</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.886</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:07 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:53 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
         \n  <ExecutionTime>0.028</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:07 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:53 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,81 +48,89 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:07 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.79</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.856</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1911']
+      content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:09 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:55 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&HostName8=delete.testid&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&RecordType8=TXT&HostId6=506046&Address8=challengetoken&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testid&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1347']
+      Content-Length: ['3928']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -128,15 +140,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.76</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['558']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:11 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:57 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -151,42 +163,80 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506050\" Name=\"delete.testid\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
+        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.933</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.845</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2100']
+      content-length: ['4784']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:12 GMT']
+      date: ['Mon, 26 Mar 2018 17:41:58 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -201,42 +251,80 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506050\" Name=\"delete.testid\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
+        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.753</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.742</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2100']
+      content-length: ['4784']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:14 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:00 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -251,54 +339,92 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506050\" Name=\"delete.testid\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524837\"\
+        \ Name=\"delete.testid\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.821</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.976</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2100']
+      content-length: ['4784']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:15 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:01 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&HostId6=506046&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1283']
+      Content-Length: ['3861']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -308,15 +434,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.944</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.688</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:17 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:02 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -331,40 +457,77 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.893</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.956</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:18 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:03 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -28,12 +28,12 @@ interactions:
         \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
         \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.192</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.375</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:37 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:05 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -113,24 +113,24 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.708</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.803</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['4596']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:39 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:06 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfqdn&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordinset&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3930']
+      Content-Length: ['3949']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -142,13 +142,13 @@ interactions:
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
         \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
         \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.871</ExecutionTime>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.141</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:40 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:07 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -184,6 +184,9 @@ interactions:
         \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
@@ -194,49 +197,76 @@ interactions:
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
         1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.794</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.744</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['4786']
+      content-length: ['4805']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:41 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:08 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524838&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordinset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken1&SLD=example-aptise&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4152']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:10 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -272,122 +302,10 @@ interactions:
         \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
-        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
-        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
-        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
-        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.967</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['4786']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.681</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:43 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
@@ -434,12 +352,221 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.681</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>1.175</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['4596']
+      content-length: ['5014']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:44 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:11 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524838\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.179</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5014']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:13 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4064']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.816</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:14 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.122</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4805']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:15 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,708 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"22\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.309</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['1493']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:17 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.916</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4805']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=challengetoken1&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4150']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.896</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:20 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5012']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524156&HostId9=524157&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524840&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken1&TTL8=60&TTL9=60&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&HostName24=_acme-challenge.deleterecordset&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=challengetoken2&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4351']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.066</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.817</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5219']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:25 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524840\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.655</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5219']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:26 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524156&HostId9=524157&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524841&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken2&TTL8=60&TTL9=60&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4265']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.764</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524841\" Name=\"_acme-challenge.deleterecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.227</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5012']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:28 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4064']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.797</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:30 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.753</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4805']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:31 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -23,17 +23,17 @@ interactions:
         \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
         \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
         \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"22\" EmailType=\"\
         FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
         \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
         \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.192</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:37 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:31 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -67,6 +67,9 @@ interactions:
         \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
@@ -113,24 +116,24 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.708</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.737</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['4596']
+      content-length: ['4805']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:39 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:33 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=delete.testfqdn&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524167&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524833&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&HostId22=524160&HostId21=524173&HostId20=524171&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524214&HostId13=524166&HostId10=524158&HostId11=524168&HostId16=524163&HostId17=524164&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=URL&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.listrecordset&HostName22=yyy&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=challengetoken1&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524170&AssociatedAppTitle19=&HostId15=524172&HostId18=524165'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3930']
+      Content-Length: ['4148']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -142,13 +145,13 @@ interactions:
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
         \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
         \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.871</ExecutionTime>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.287</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:40 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:35 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -184,18 +187,21 @@ interactions:
         \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
         \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
         \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
@@ -231,12 +237,42 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.794</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.88</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['4786']
+      content-length: ['5009']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:41 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:36 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524168&HostId13=524214&HostId10=524833&HostId11=524158&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=updated&TTL21=1800&TTL20=1800&HostName24=_acme-challenge.listrecordset&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=challengetoken2&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4347']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.993</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:42:37 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -272,18 +308,24 @@ interactions:
         \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
         TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
         \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
         \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524835\"\
-        \ Name=\"delete.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
         \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
@@ -319,127 +361,12 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.967</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.74</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['4786']
+      content-length: ['5214']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:42 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode 'RecordType21=URL&HostId19=524171&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524833&HostId9=524158&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524156&HostId7=524157&HostId21=524160&HostId20=524173&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524166&HostId13=524170&HostId10=524168&HostId11=524214&HostId16=524164&HostId17=524165&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&FriendlyName21=URL+Record&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=60&TTL7=60&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=yyy&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&Address21=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524172&AssociatedAppTitle19=&HostId15=524163&HostId18=524167'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3861']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.681</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:43 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
-        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
-        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
-        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
-        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524833\" Name=\"_acme-challenge.noop\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524158\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\"\
-        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524214\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
-        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
-        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.681</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['4596']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:44 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:38 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.079</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.059</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:18 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:39 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,81 +48,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.016</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:18 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.789</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.716</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1912']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:19 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:41 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&TTL5=1800&MXPref3=10&HostName7=%40&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&HostName8=random.fqdntest&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&TTL6=1800&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref5=10&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=URL+Record&AssociatedAppTitle1=&MXPref6=10&HostId7=505697&AssociatedAppTitle5=&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL4=1800&RecordType8=TXT&HostId6=506046&Address8=challengetoken&RecordType6=TXT&RecordType7=URL&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.fqdntest&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1349']
+      Content-Length: ['4531']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -128,15 +149,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.858</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.88</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['558']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:21 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:42 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -151,42 +172,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.899</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.759</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2102']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:23 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:44 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.021</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.038</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:23 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:44 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,83 +48,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:24 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.814</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.913</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2102']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:25 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:46 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'AssociatedAppTitle6=&Address3=parkingpage.namecheap.com.&AssociatedAppTitle8=&TTL5=1800&MXPref3=10&HostName7=random.fqdntest&IsDDNSEnabled7=false&TTL1=1800&IsDDNSEnabled3=false&HostName9=random.fulltest&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&IsActive2=true&HostName8=%40&FriendlyName5=&TTL7=1800&HostId2=506043&FriendlyName4=&Address4=challengetoken&Address9=challengetoken&TTL6=1800&IsDDNSEnabled8=false&MXPref8=10&IsDDNSEnabled6=false&Address1=127.0.0.1&TTL2=1800&TTL3=1800&IsDDNSEnabled2=false&MXPref2=10&MXPref1=10&IsDDNSEnabled1=false&AssociatedAppTitle4=&MXPref7=10&SLD=lexicontest&Address5=challengetoken&IsDDNSEnabled4=false&Address7=challengetoken&MXPref5=10&IsActive8=true&FriendlyName1=&AssociatedAppTitle7=&FriendlyName3=CName+Record&FriendlyName2=&AssociatedAppTitle2=&AssociatedAppTitle3=&FriendlyName7=&AssociatedAppTitle1=&MXPref6=10&FriendlyName8=URL+Record&HostId7=506051&AssociatedAppTitle5=&HostId8=505697&Address6=challengetoken&IsActive7=true&IsDDNSEnabled5=false&FriendlyName6=&TLD=com&IsActive3=true&HostId1=506042&IsActive1=true&HostId3=506041&HostId4=506044&HostId5=506045&IsActive5=true&IsActive4=true&TTL8=1800&TTL4=1800&RecordType8=URL&HostId6=506046&Address8=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType9=TXT&Address2=docs.example.com.&MXPref4=10&IsActive6=true'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=random.fulltest&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1523']
+      Content-Length: ['4531']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -130,15 +149,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.929</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.267</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:27 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:48 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -153,45 +172,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\"\
-        \ Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.778</ExecutionTime>\r\n</ApiResponse>"}
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.844</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2292']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:28 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:49 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -23,17 +23,17 @@ interactions:
         \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
         \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
         \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
         FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
         \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
         \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.033</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.201</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:02 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:49 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -63,11 +63,28 @@ interactions:
         false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"524157\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
         \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
@@ -105,42 +122,12 @@ interactions:
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.822</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.721</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3987']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:03 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=URL&RecordType19=CNAME&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524214&HostId9=524166&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524156&HostId5=524157&HostId6=524158&HostId7=524168&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&FriendlyName18=URL+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524163&HostId13=524164&HostId10=524170&HostId11=524172&HostId16=524171&HostId17=524173&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=60&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=yyy&HostName19=docs&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=60&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address19=docs.example.com&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524165&HostId15=524167&HostId18=524160'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['3332']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
-        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.963</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['559']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:41:05 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:52 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.016</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.181</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:35 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:57 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,77 +48,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:36 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.843</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.192</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2478']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:37 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:59 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.021</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.104</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:37 GMT']
+      date: ['Mon, 26 Mar 2018 17:42:59 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,89 +48,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.014</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:37 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"\
-        URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.969</ExecutionTime>\r\n</ApiResponse>"}
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.957</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2478']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:39 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:03 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled10=false&RecordType10=URL&RecordType11=TXT&HostId8=506052&HostId9=506053&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506051&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&AssociatedAppTitle2=&AssociatedAppTitle3=&HostId10=505697&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName10=%40&HostName11=orig.test&Address1=127.0.0.1&MXPref5=10&TTL3=1800&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TLD=com&FriendlyName10=URL+Record&Address2=docs.example.com.&MXPref10=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=random.fqdntest&HostName8=random.fulltest&HostName9=random.test&Address10=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&Address11=challengetoken&MXPref6=10&TTL10=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['1874']
+      Content-Length: ['4525']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -136,15 +149,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.055</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.081</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:40 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:05 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -159,50 +172,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\" Name=\"orig.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.922</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.977</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2662']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:41 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:08 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -217,50 +266,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\" Name=\"orig.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.795</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.004</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2662']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:43 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:09 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -275,62 +360,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\" Name=\"orig.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.883</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.752</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2662']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:44 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:11 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled10=false&IsDDNSEnabled11=false&RecordType10=TXT&RecordType11=URL&RecordType12=TXT&HostId8=506051&HostId9=506052&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506054&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=URL+Record&AssociatedAppTitle2=&AssociatedAppTitle3=&HostId10=506053&HostId11=505697&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=updated.test&HostName10=random.test&HostName11=%40&Address1=127.0.0.1&MXPref5=10&IsActive11=true&TTL3=1800&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&MXPref11=10&MXPref10=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.test&HostName8=random.fqdntest&HostName9=random.fulltest&Address10=challengetoken&Address11=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref6=10&TTL10=1800&TTL11=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2055']
+      Content-Length: ['4528']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -340,15 +461,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.952</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.019</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:47 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:12 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.015</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.043</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:47 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:12 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,94 +48,437 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.016</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:47 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\" Name=\"orig.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.679</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5215']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:14 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.nameonly.test&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524214&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4534']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.742</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5215']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:16 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524214\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.943</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['5215']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:18 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4282']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.996</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['559']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
+        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524166\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524163\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\"\
         \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524165\" Name=\"random.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506055\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524167\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"\
-        @\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.873</ExecutionTime>\r\n</ApiResponse>"}
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524171\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524160\" Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.794</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['2849']
+      content-length: ['5029']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:49 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:21 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&RecordType10=TXT&RecordType11=TXT&RecordType12=URL&RecordType13=TXT&HostId8=506051&HostId9=506052&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506054&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName12=URL+Record&AssociatedAppTitle3=&HostId12=505697&HostId10=506053&HostId11=506055&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=%40&HostName13=orig.nameonly.test&HostName10=random.test&HostName11=updated.test&Address1=127.0.0.1&MXPref5=10&IsActive12=true&IsActive11=true&TTL3=1800&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&AssociatedAppTitle12=&Address13=challengetoken&MXPref12=10&MXPref11=10&MXPref10=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.test&HostName8=random.fqdntest&HostName9=random.fulltest&Address10=challengetoken&Address11=challengetoken&MXPref6=10&TTL12=1800&TTL10=1800&TTL11=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524165&RecordType20=TXT&RecordType23=URL&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId23=524160&HostId22=524173&HostId21=524171&HostId20=524167&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524172&HostId17=524163&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=URL+Record&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.nameonly.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=yyy&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise&MXPref4=10&Address24=updated&Address23=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524166&AssociatedAppTitle19=&HostId15=524170&HostId18=524164'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2242']
+      Content-Length: ['4347']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -141,173 +488,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.028</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.748</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:50 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506054\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"\
-        random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506053\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"\
-        http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\
-        \n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.854</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['3042']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:51 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
-        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
-        parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
-        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
-        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
-        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506054\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"\
-        random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506053\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"\
-        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
-        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"\
-        http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\
-        \n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.718</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['3042']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:53 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=URL&RecordType14=TXT&HostId8=506054&HostId9=506051&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506056&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=URL+Record&FriendlyName12=&AssociatedAppTitle3=&HostId12=506055&HostId13=505697&HostId10=506052&HostId11=506053&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=updated.test&HostName13=%40&HostName10=random.fulltest&HostName11=random.test&HostName14=orig.nameonly.test&Address1=127.0.0.1&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&Address13=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.test&HostName9=random.fqdntest&Address10=challengetoken&Address11=challengetoken&MXPref6=10&Address14=updated&TTL12=1800&TTL13=1800&TTL10=1800&TTL11=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['2422']
-      Content-Type: [application/x-www-form-urlencoded]
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.953</ExecutionTime>\r\
-        \n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['556']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:55 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:22 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.017</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.034</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:55 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:23 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,99 +48,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.089</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:55 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\" Name=\"random.fqdntest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506052\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\"\
-        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
-        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"updated.test\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.821</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.732</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3228']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:57 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:24 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=URL&RecordType15=TXT&HostId8=506057&HostId9=506054&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506056&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName14=URL+Record&AssociatedAppTitle3=&HostId12=506053&HostId13=506055&HostId10=506051&HostId11=506052&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.test&HostName13=updated.test&HostName10=random.fqdntest&HostName11=random.fulltest&HostName14=%40&Address1=127.0.0.1&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref14=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&MXPref6=10&Address14=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&TTL11=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10&HostId14=505697'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.testfqdn&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2604']
+      Content-Length: ['4529']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -146,15 +149,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.036</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.838</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:58 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:26 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -169,61 +172,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506055\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"\
-        @\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>1.106</ExecutionTime>\r\n</ApiResponse>"}
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.694</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3416']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:04:59 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:27 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -238,61 +266,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506055\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"\
-        @\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.888</ExecutionTime>\r\n</ApiResponse>"}
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.599</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3416']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:01 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:27 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -307,73 +360,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506055\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"505697\" Name=\"\
-        @\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\" MXPref=\"\
-        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.977</ExecutionTime>\r\n</ApiResponse>"}
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.777</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3416']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:02 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:29 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=URL&RecordType16=TXT&HostId8=506057&HostId9=506054&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506056&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=URL+Record&FriendlyName14=&AssociatedAppTitle3=&HostId12=506052&HostId13=506053&HostId10=506058&HostId11=506051&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fulltest&HostName13=random.test&HostName10=orig.testfqdn&HostName11=random.fqdntest&HostName16=updated.testfqdn&HostName14=updated.test&Address1=127.0.0.1&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&TTL12=1800&TTL13=1800&TTL10=1800&TTL11=1800&Address5=challengetoken&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=%40&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10&HostId14=506055&HostId15=505697'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.testfqdn&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2789']
+      Content-Length: ['4532']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -383,15 +461,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.588</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.064</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:05 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:30 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -8,28 +8,32 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=1
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult>\r\
-        \n      <Domain ID=\"160248\" Name=\"dnscontrol.com\" User=\"sandypants\"\
-        \ Created=\"04/18/2017\" Expires=\"04/18/2018\" IsExpired=\"false\" IsLocked=\"\
-        false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"false\"\
-        \ IsOurDNS=\"true\" />\r\n      <Domain ID=\"261173\" Name=\"lexicontest.com\"\
-        \ User=\"sandypants\" Created=\"01/16/2018\" Expires=\"01/16/2019\" IsExpired=\"\
-        false\" IsLocked=\"false\" AutoRenew=\"false\" WhoisGuard=\"NOTPRESENT\" IsPremium=\"\
-        false\" IsOurDNS=\"true\" />\r\n    </DomainGetListResult>\r\n    <Paging>\r\
-        \n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>1</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
+        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
+        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"24\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.112</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1053']
+      content-length: ['1493']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:05 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:31 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -44,105 +48,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getList&Page=2
-  response:
-    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
-        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
-        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getlist</RequestedCommand>\r\
-        \n  <CommandResponse Type=\"namecheap.domains.getList\">\r\n    <DomainGetListResult\
-        \ />\r\n    <Paging>\r\n      <TotalItems>2</TotalItems>\r\n      <CurrentPage>2</CurrentPage>\r\
-        \n      <PageSize>20</PageSize>\r\n    </Paging>\r\n  </CommandResponse>\r\
-        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.015</ExecutionTime>\r\n</ApiResponse>"}
-    headers:
-      cache-control: [private]
-      content-length: ['580']
-      content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:06 GMT']
-      server: [Microsoft-IIS/8.5]
-      vary: [Accept-Encoding]
-      x-aspnet-version: [4.0.30319]
-      x-powered-by: [ASP.NET]
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-    method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506051\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\"\
-        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506053\" Name=\"random.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506055\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506059\" Name=\"\
-        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
         1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"\
-        http://www.lexicontest.com/?from=@\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
-        \" FriendlyName=\"URL Record\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\
-        \n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.079</ExecutionTime>\r\
-        \n</ApiResponse>"}
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
+        \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3607']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:07 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:33 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=URL&RecordType17=TXT&HostId8=506057&HostId9=506054&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506056&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&AssociatedAppTitle3=&HostId12=506052&HostId13=506053&HostId10=506058&HostId11=506051&HostId16=505697&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fulltest&HostName13=random.test&HostName10=orig.testfqdn&HostName11=random.fqdntest&HostName16=%40&HostName17=orig.testfull&HostName14=updated.test&Address1=127.0.0.1&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=URL+Record&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10&HostId14=506055&HostId15=506059'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=orig.testfull&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['2971']
+      Content-Length: ['4529']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -152,15 +149,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>1.211</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.755</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:09 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:34 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -175,66 +172,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506060\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
         \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\" Name=\"random.fulltest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506053\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
         updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
         1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506059\" Name=\"updated.testfqdn\" Type=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.978</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.601</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3795']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:10 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:34 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -249,66 +266,86 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506060\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
         \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\" Name=\"random.fulltest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506053\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
         updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
         1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506059\" Name=\"updated.testfqdn\" Type=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.987</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.737</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3795']
+      content-length: ['5215']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:12 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:38 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
@@ -323,78 +360,98 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=lexicontest&TLD=com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise&TLD=com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
-        \ Domain=\"lexicontest.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\n\
-        \      <host HostId=\"506042\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
-        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506043\" Name=\"\
-        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"1800\"\
+        \ Domain=\"example-aptise.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\">\r\
+        \n      <host HostId=\"524154\" Name=\"localhost\" Type=\"A\" Address=\"127.0.0.1\"\
+        \ MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524155\" Name=\"\
+        docs\" Type=\"CNAME\" Address=\"docs.example.com.\" MXPref=\"10\" TTL=\"60\"\
         \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506041\" Name=\"www\" Type=\"CNAME\" Address=\"\
+        false\" />\r\n      <host HostId=\"524153\" Name=\"xxxx\" Type=\"CNAME\" Address=\"\
         parkingpage.namecheap.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"CName Record\" IsActive=\"true\" IsDDNSEnabled=\"false\"\
-        \ />\r\n      <host HostId=\"506044\" Name=\"_acme-challenge.fqdn\" Type=\"\
-        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \ />\r\n      <host HostId=\"524831\" Name=\"_acme-challenge.createrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506045\" Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524832\" Name=\"_acme-challenge.createrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524839\" Name=\"_acme-challenge.deleterecordinset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524156\" Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524157\"\
+        \ Name=\"_acme-challenge.full\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"60\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524842\" Name=\"_acme-challenge.listrecordset\"\
+        \ Type=\"TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524843\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524833\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506046\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524158\"\
         \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506056\" Name=\"orig.nameonly.test\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524168\" Name=\"orig.nameonly.test\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506057\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524844\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
         updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506054\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524166\"\
         \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
         \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506058\" Name=\"orig.testfqdn\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524170\" Name=\"orig.testfqdn\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506060\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        \  <host HostId=\"524172\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
         challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
-        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506051\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524163\"\
         \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
         10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
-        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506052\" Name=\"random.fulltest\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524164\" Name=\"random.fulltest\"\
         \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"506053\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \  <host HostId=\"524165\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
-        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"506055\" Name=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524167\" Name=\"\
         updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
         1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
-        false\" />\r\n      <host HostId=\"506059\" Name=\"updated.testfqdn\" Type=\"\
+        false\" />\r\n      <host HostId=\"524171\" Name=\"updated.testfqdn\" Type=\"\
         TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
         \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
-        \  <host HostId=\"505697\" Name=\"@\" Type=\"URL\" Address=\"http://www.lexicontest.com/?from=@\"\
+        \  <host HostId=\"524173\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524160\"\
+        \ Name=\"yyy\" Type=\"URL\" Address=\"http://www.example-aptise.com/?from=@\"\
         \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"URL Record\"\
         \ IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
-        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.868</ExecutionTime>\r\n</ApiResponse>"}
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.09</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['3795']
+      content-length: ['5214']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:13 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:39 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]
       x-powered-by: [ASP.NET]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=URL&HostId8=506057&HostId9=506054&FriendlyName6=&AssociatedAppTitle10=&HostId1=506042&HostId2=506043&HostId3=506041&HostId4=506044&HostId5=506045&HostId6=506046&HostId7=506056&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=CName+Record&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=URL+Record&AssociatedAppTitle3=&HostId12=506051&HostId13=506052&HostId10=506058&HostId11=506060&HostId16=506059&HostId17=505697&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=%40&HostName14=random.test&Address1=127.0.0.1&HostName18=updated.testfull&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1800&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=docs&HostName3=www&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=http%3A%2F%2Fwww.lexicontest.com%2F%3Ffrom%3D%40&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=lexicontest&MXPref4=10&HostId14=506053&HostId15=506055'
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524164&RecordType20=TXT&RecordType23=TXT&MXPref24=10&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524157&HostId9=524842&IsDDNSEnabled24=false&FriendlyName6=&AssociatedAppTitle10=&HostId1=524154&HostId2=524155&HostId3=524153&HostId4=524831&HostId5=524832&HostId6=524839&HostId7=524156&IsDDNSEnabled22=false&MXPref23=10&HostId24=524160&HostId23=524173&HostId22=524171&HostId21=524167&HostId20=524165&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=CNAME&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=CName+Record&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524158&HostId13=524168&HostId10=524843&HostId11=524833&HostId16=524170&HostId17=524172&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&FriendlyName24=URL+Record&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=60&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=60&TTL2=60&Address3=parkingpage.namecheap.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=60&TTL14=1800&RecordType24=URL&TTL24=1800&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=yyy&TTL15=1800&TLD=com&FriendlyName10=&Address2=docs.example.com.&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&AssociatedAppTitle24=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&RecordType25=TXT&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=docs&HostName3=xxxx&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&HostName25=updated.testfull&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&IsActive24=true&SLD=example-aptise&MXPref4=10&Address25=challengetoken&Address24=http%3A%2F%2Fwww.example-aptise.com%2F%3Ffrom%3D%40&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524844&AssociatedAppTitle19=&HostId15=524166&HostId18=524163'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Length: ['3156']
+      Content-Length: ['4532']
       Content-Type: [application/x-www-form-urlencoded]
       User-Agent: [python-requests/2.18.4]
     method: POST
@@ -404,15 +461,15 @@ interactions:
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
-        \ Domain=\"lexicontest.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\n\
-        \    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
-        \n  <GMTTimeDifference>--8:00</GMTTimeDifference>\r\n  <ExecutionTime>0.939</ExecutionTime>\r\
+        \ Domain=\"example-aptise.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.802</ExecutionTime>\r\
         \n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['556']
+      content-length: ['559']
       content-type: [text/xml; charset=utf-8]
-      date: ['Wed, 17 Jan 2018 19:05:15 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:40 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_authenticate.yaml
@@ -8,32 +8,39 @@ interactions:
       Content-Length: ['0']
       User-Agent: [python-requests/2.18.4]
     method: POST
-    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise.com
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
   response:
     body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
         <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
         >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
         \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
-        \ Status=\"Ok\" ID=\"277432\" DomainName=\"example-aptise.com\" OwnerName=\"\
-        jvsandbox\" IsOwner=\"true\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
-        \n        <CreatedDate>03/25/2018</CreatedDate>\r\n        <ExpiredDate>03/25/2019</ExpiredDate>\r\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
         \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
-        \ />\r\n      <Whoisguard Enabled=\"NotAlloted\">\r\n        <ID>0</ID>\r\n\
-        \      </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
         \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
         \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
         \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
-        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"18\" EmailType=\"\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
         FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
         \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
-        \n      <Modificationrights All=\"true\" />\r\n    </DomainGetInfoResult>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.849</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.683</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
-      content-length: ['1493']
+      content-length: ['2034']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:40:58 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:42 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -25,12 +25,12 @@ interactions:
         \ IsUsingOurDNS=\"false\" HostCount=\"0\" DynamicDNSStatus=\"false\" IsFailover=\"\
         false\" />\r\n      <Modificationrights />\r\n    </DomainGetInfoResult>\r\
         \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
-        \n  <ExecutionTime>0.191</ExecutionTime>\r\n</ApiResponse>"}
+        \n  <ExecutionTime>0.359</ExecutionTime>\r\n</ApiResponse>"}
     headers:
       cache-control: [private]
       content-length: ['1189']
       content-type: [text/xml; charset=utf-8]
-      date: ['Mon, 26 Mar 2018 17:40:58 GMT']
+      date: ['Mon, 26 Mar 2018 17:43:42 GMT']
       server: [Microsoft-IIS/8.5]
       vary: [Accept-Encoding]
       x-aspnet-version: [4.0.30319]

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.214</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:44 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.712</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:45 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=A&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=localhost&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=127.0.0.1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3083']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:47 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.063</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:48 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.109</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:50 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=CNAME&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=docs&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=docs.example.com&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3089']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.769</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:51 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.032</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:53 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.835</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:54 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.fqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3101']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.72</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['560']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:55 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:55 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.945</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:57 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.full&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3101']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.642</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:58 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.032</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:43:58 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.814</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:00 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.test&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3101']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.16</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['560']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:02 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,258 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"17\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.066</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:02 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\"\
+        \ Name=\"_acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.874</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3752']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:04 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524206&HostId9=524203&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524193&HostId5=524194&HostId6=524195&HostId7=524205&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524200&HostId13=524201&HostId10=524207&HostId11=524209&HostId16=524208&HostId17=524210&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=updated&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=random.fqdntest&HostName13=random.fulltest&HostName10=orig.testfqdn&HostName11=orig.testfull&HostName16=updated.testfqdn&HostName17=updated.testfull&HostName14=random.test&Address1=127.0.0.1&HostName18=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken1&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.fqdn&HostName5=_acme-challenge.full&HostName6=_acme-challenge.test&HostName7=orig.nameonly.test&HostName8=orig.nameonly.test&HostName9=orig.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=updated.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&HostId14=524202&HostId15=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3113']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.963</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:05 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.874</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['3959']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:06 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'IsActive10=true&IsDDNSEnabled18=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524205&HostId9=524206&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524193&HostId6=524194&HostId7=524195&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524209&HostId13=524200&HostId10=524203&HostId11=524207&HostId16=524204&HostId17=524208&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=updated&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfull&HostName13=random.fqdntest&HostName10=orig.test&HostName11=orig.testfqdn&HostName16=updated.test&HostName17=updated.testfqdn&HostName14=random.fulltest&Address1=127.0.0.1&HostName18=updated.testfull&HostName19=_acme-challenge.createrecordset&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken2&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.fqdn&HostName6=_acme-challenge.full&HostName7=_acme-challenge.test&HostName8=orig.nameonly.test&HostName9=orig.nameonly.test&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&AssociatedAppTitle18=&HostId14=524201&HostId15=524202&HostId18=524210'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3314']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.715</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:07 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,352 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"19\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.035</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:07 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524195\" Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.846</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4166']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:09 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524210&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524195&HostId9=524205&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524207&HostId13=524209&HostId10=524206&HostId11=524203&HostId16=524202&HostId17=524204&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.testfqdn&HostName13=orig.testfull&HostName10=orig.nameonly.test&HostName11=orig.test&HostName16=random.test&HostName17=updated.test&HostName14=random.fqdntest&Address1=127.0.0.1&HostName18=updated.testfqdn&HostName19=updated.testfull&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.test&HostName9=orig.nameonly.test&Address10=updated&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=_acme-challenge.noop&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fulltest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524200&AssociatedAppTitle19=&HostId15=524201&HostId18=524208'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3503']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.777</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:10 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.938</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:12 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.noop&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3692']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.061</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:13 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.717</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,443 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.044</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.738</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:16 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfilt&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3687']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.915</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:18 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524848\" Name=\"delete.testfilt\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.876</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4551']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524848\" Name=\"delete.testfilt\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.137</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4551']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3618']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.658</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:22 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.754</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,443 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.292</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.829</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfqdn&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3687']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.989</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:29 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524849\" Name=\"delete.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.95</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4550']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:31 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524849\" Name=\"delete.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.981</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4551']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3618']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.721</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:34 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.895</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:35 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,443 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.199</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:37 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.736</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:38 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testfull&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3687']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.767</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:39 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524850\" Name=\"delete.testfull\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.636</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4551']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:40 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524850\" Name=\"delete.testfull\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.599</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4551']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:40 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3618']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.733</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:42 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.758</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:44 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,528 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.035</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:44 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.692</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:45 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=delete.testid&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3685']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.82</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['560']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:47 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.191</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4549']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:48 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.772</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4549']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:50 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524851\" Name=\"delete.testid\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524205\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524206\"\
+        \ Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"updated\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\" Name=\"orig.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524207\" Name=\"orig.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524209\"\
+        \ Name=\"orig.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\" Name=\"random.fqdntest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524201\" Name=\"random.fulltest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\"\
+        \ Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"updated.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524210\"\
+        \ Name=\"updated.testfull\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\n  </CommandResponse>\r\
+        \n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.094</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4549']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:52 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3618']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.742</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:53 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.672</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:54 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,567 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"20\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.354</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:54 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.002</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4361']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:56 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524208&RecordType20=TXT&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524847&HostId9=524195&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524193&HostId7=524194&HostId20=524210&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524203&HostId13=524207&HostId10=524205&HostId11=524206&HostId16=524201&HostId17=524202&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.test&HostName13=orig.testfqdn&HostName10=orig.nameonly.test&HostName11=orig.nameonly.test&HostName16=random.fulltest&HostName17=random.test&HostName14=orig.testfull&Address1=127.0.0.1&HostName18=updated.test&HostName19=updated.testfqdn&MXPref5=10&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle20=&Address12=challengetoken&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.fqdn&HostName7=_acme-challenge.full&HostName8=_acme-challenge.noop&HostName9=_acme-challenge.test&Address10=challengetoken&Address11=updated&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=_acme-challenge.deleterecordinset&HostName20=updated.testfull&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=random.fqdntest&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken1&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524209&AssociatedAppTitle19=&HostId15=524200&HostId18=524204'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3706']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.93</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['560']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:44:58 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.863</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4570']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:00 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524852&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken2&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordinset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken1&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3909']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.752</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:01 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.251</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4779']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:02 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524852\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.707</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4779']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:04 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3821']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.826</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:05 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.651</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4570']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:06 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,697 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.219</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:06 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.925</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4570']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:08 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.deleterecordset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3907']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.797</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:10 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.691</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4777']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:11 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524193&HostId9=524194&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524854&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken1&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.deleterecordset&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4108']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.077</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:12 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.866</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4984']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:14 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524854\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.622</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4984']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524193&HostId9=524194&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524855&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken2&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.deleterecordset&HostName8=_acme-challenge.fqdn&HostName9=_acme-challenge.full&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4022']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.029</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:16 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524855\" Name=\"\
+        _acme-challenge.deleterecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.865</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4777']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:18 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3821']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.778</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:19 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.719</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4570']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,373 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"21\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.204</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.875</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4570']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524204&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524847&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&HostId21=524210&HostId20=524208&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524206&HostId13=524203&HostId10=524195&HostId11=524205&HostId16=524200&HostId17=524201&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken1&HostName12=orig.nameonly.test&HostName13=orig.test&HostName10=_acme-challenge.test&HostName11=orig.nameonly.test&HostName16=random.fqdntest&HostName17=random.fulltest&HostName14=orig.testfqdn&Address1=127.0.0.1&HostName18=random.test&HostName19=updated.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=updated&Address18=challengetoken&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.noop&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=_acme-challenge.listrecordset&HostName21=updated.testfull&HostName20=updated.testfqdn&TTL10=1800&Address17=challengetoken&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfull&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524207&AssociatedAppTitle19=&HostId15=524209&HostId18=524202'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['3905']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.932</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:25 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.662</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4775']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:26 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524205&HostId13=524206&HostId10=524847&HostId11=524195&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=orig.nameonly.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.noop&HostName11=_acme-challenge.test&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=updated&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=_acme-challenge.listrecordset&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=challengetoken2&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4104']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.717</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:27 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.881</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:28 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,261 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:28 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.699</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:30 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.fqdntest&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4288']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.945</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:32 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.681</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,261 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.029</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:33 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.968</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:35 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.fulltest&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4288']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.885</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:37 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.831</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:38 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.189</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:38 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.886</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:40 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,261 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.067</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:40 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.781</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:42 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=random.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4284']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.863</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:43 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.96</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4979']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:45 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,140 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.047</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:45 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.752</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:47 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,473 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.238</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:47 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.004</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:49 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4282']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.037</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:50 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.806</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:51 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.782</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:52 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.046</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:54 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4285']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.005</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:55 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,500 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.232</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:55 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>1.043</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:58 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.nameonly.test&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524206&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4291']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.726</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:45:59 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.818</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:00 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524206\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.669</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:02 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4039']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.934</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:03 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524203\" Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"\
+        orig.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524200\" Name=\"random.fqdntest\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\"\
+        \ Name=\"random.fulltest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524202\" Name=\"random.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524204\" Name=\"updated.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524208\" Name=\"\
+        updated.testfqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.741</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4794']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:04 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524202&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&HostId22=524210&HostId21=524208&HostId20=524204&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524209&HostId17=524200&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfull&HostName17=random.fqdntest&HostName14=orig.test&Address1=127.0.0.1&HostName18=random.fulltest&HostName19=random.test&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=challengetoken&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=orig.nameonly.test&HostName22=updated.testfull&HostName21=updated.testfqdn&HostName20=updated.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.testfqdn&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address23=updated&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524203&AssociatedAppTitle19=&HostId15=524207&HostId18=524201'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4104']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.849</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:06 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,473 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.039</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:07 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.689</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:08 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.testfqdn&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4286']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>1.003</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:10 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.892</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:11 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.938</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:12 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.796</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:14 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.testfqdn&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4289']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.98</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['560']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/namecheap/managed-IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,473 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.getInfo&DomainName=example-aptise-2.com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.getinfo</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.getInfo\">\r\n    <DomainGetInfoResult\
+        \ Status=\"Ok\" ID=\"277442\" DomainName=\"example-aptise-2.com\" OwnerName=\"\
+        jvsandbox2\" IsOwner=\"false\" IsPremium=\"false\">\r\n      <DomainDetails>\r\
+        \n        <CreatedDate>03/26/2018</CreatedDate>\r\n        <ExpiredDate>03/26/2019</ExpiredDate>\r\
+        \n        <NumYears>0</NumYears>\r\n      </DomainDetails>\r\n      <LockDetails\
+        \ />\r\n      <Whoisguard Enabled=\"True\">\r\n        <ID>233216</ID>\r\n\
+        \        <ExpiredDate>03/25/2019</ExpiredDate>\r\n        <EmailDetails WhoisGuardEmail=\"\
+        bdf487b65d844ddfafe33163f0e709f0.protect@whoisguard.com\" ForwardedTo=\"namecheap.sandbox.2@2xlp.com\"\
+        \ LastAutoEmailChangeDate=\"\" AutoEmailChangeFrequencyDays=\"0\" />\r\n \
+        \     </Whoisguard>\r\n      <PremiumDnsSubscription>\r\n        <UseAutoRenew>false</UseAutoRenew>\r\
+        \n        <SubscriptionId>-1</SubscriptionId>\r\n        <CreatedDate>0001-01-01T00:00:00</CreatedDate>\r\
+        \n        <ExpirationDate>0001-01-01T00:00:00</ExpirationDate>\r\n       \
+        \ <IsActive>false</IsActive>\r\n      </PremiumDnsSubscription>\r\n      <DnsDetails\
+        \ ProviderType=\"FREE\" IsUsingOurDNS=\"true\" HostCount=\"23\" EmailType=\"\
+        FWD\" DynamicDNSStatus=\"false\" IsFailover=\"false\">\r\n        <Nameserver>dns1.registrar-servers.com</Nameserver>\r\
+        \n        <Nameserver>dns2.registrar-servers.com</Nameserver>\r\n      </DnsDetails>\r\
+        \n      <Modificationrights All=\"false\">\r\n        <Rights Type=\"dns\"\
+        >OK</Rights>\r\n        <Rights Type=\"hosts\">OK</Rights>\r\n        <Rights\
+        \ Type=\"ddns\">OK</Rights>\r\n        <Rights Type=\"nameserver\">OK</Rights>\r\
+        \n        <Rights Type=\"premiumDns\">OK</Rights>\r\n        <Rights Type=\"\
+        dnsSec\">OK</Rights>\r\n      </Modificationrights>\r\n    </DomainGetInfoResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.051</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['2034']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:15 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.686</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:17 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=orig.testfull&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4286']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.934</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:18 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.616</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:20 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.668</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:21 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.getHosts&SLD=example-aptise-2&TLD=com
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.gethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.getHosts\">\r\n    <DomainDNSGetHostsResult\
+        \ Domain=\"example-aptise-2.com\" EmailType=\"FWD\" IsUsingOurDNS=\"true\"\
+        >\r\n      <host HostId=\"524191\" Name=\"localhost\" Type=\"A\" Address=\"\
+        127.0.0.1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524190\"\
+        \ Name=\"www\" Type=\"A\" Address=\"127.0.0.1\" MXPref=\"10\" TTL=\"1799\"\
+        \ AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524192\" Name=\"docs\" Type=\"CNAME\" Address=\"\
+        docs.example.com.\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524845\"\
+        \ Name=\"_acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken1\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524846\" Name=\"\
+        _acme-challenge.createrecordset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524853\" Name=\"\
+        _acme-challenge.deleterecordinset\" Type=\"TXT\" Address=\"challengetoken2\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524193\" Name=\"\
+        _acme-challenge.fqdn\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524194\" Name=\"_acme-challenge.full\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524856\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken1\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524857\" Name=\"_acme-challenge.listrecordset\" Type=\"\
+        TXT\" Address=\"challengetoken2\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524847\" Name=\"_acme-challenge.noop\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524195\"\
+        \ Name=\"_acme-challenge.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524205\" Name=\"orig.nameonly.test\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524858\" Name=\"orig.nameonly.test\" Type=\"TXT\" Address=\"\
+        updated\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524203\"\
+        \ Name=\"orig.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\"\
+        \ TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524207\" Name=\"orig.testfqdn\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524209\" Name=\"orig.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524200\"\
+        \ Name=\"random.fqdntest\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"\
+        10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\"\
+        \ IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524201\" Name=\"random.fulltest\"\
+        \ Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524202\" Name=\"random.test\" Type=\"TXT\" Address=\"challengetoken\"\
+        \ MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"\
+        true\" IsDDNSEnabled=\"false\" />\r\n      <host HostId=\"524204\" Name=\"\
+        updated.test\" Type=\"TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"\
+        1800\" AssociatedAppTitle=\"\" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"\
+        false\" />\r\n      <host HostId=\"524208\" Name=\"updated.testfqdn\" Type=\"\
+        TXT\" Address=\"challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\
+        \" FriendlyName=\"\" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    \
+        \  <host HostId=\"524210\" Name=\"updated.testfull\" Type=\"TXT\" Address=\"\
+        challengetoken\" MXPref=\"10\" TTL=\"1800\" AssociatedAppTitle=\"\" FriendlyName=\"\
+        \" IsActive=\"true\" IsDDNSEnabled=\"false\" />\r\n    </DomainDNSGetHostsResult>\r\
+        \n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\
+        \n  <ExecutionTime>0.723</ExecutionTime>\r\n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['4980']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:22 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode 'RecordType21=TXT&HostId19=524201&RecordType20=TXT&RecordType23=TXT&IsDDNSEnabled21=false&IsActive10=true&IsDDNSEnabled18=false&IsDDNSEnabled19=false&AssociatedAppTitle11=&IsDDNSEnabled14=false&IsDDNSEnabled15=false&IsDDNSEnabled16=false&IsDDNSEnabled17=false&IsDDNSEnabled10=false&IsDDNSEnabled11=false&IsDDNSEnabled12=false&IsDDNSEnabled13=false&AssociatedAppTitle13=&IsDDNSEnabled20=false&AssociatedAppTitle14=&AssociatedAppTitle15=&AssociatedAppTitle16=&AssociatedAppTitle17=&RecordType18=TXT&RecordType19=TXT&IsDDNSEnabled23=false&RecordType10=TXT&RecordType11=TXT&RecordType12=TXT&RecordType13=TXT&RecordType14=TXT&RecordType15=TXT&RecordType16=TXT&RecordType17=TXT&HostId8=524194&HostId9=524856&FriendlyName6=&AssociatedAppTitle10=&HostId1=524191&HostId2=524190&HostId3=524192&HostId4=524845&HostId5=524846&HostId6=524853&HostId7=524193&IsDDNSEnabled22=false&MXPref23=10&HostId23=524210&HostId22=524208&HostId21=524204&HostId20=524202&RecordType6=TXT&RecordType7=TXT&RecordType4=TXT&RecordType5=TXT&RecordType2=A&RecordType3=CNAME&RecordType1=A&RecordType8=TXT&RecordType9=TXT&FriendlyName1=&IsActive21=true&MXPref20=10&FriendlyName3=&FriendlyName19=&FriendlyName18=&AssociatedAppTitle5=&FriendlyName11=&AssociatedAppTitle2=&FriendlyName13=&FriendlyName12=&FriendlyName15=&FriendlyName14=&FriendlyName17=&AssociatedAppTitle3=&HostId12=524195&HostId13=524205&HostId10=524857&HostId11=524847&HostId16=524207&HostId17=524209&IsDDNSEnabled8=false&IsDDNSEnabled9=false&IsDDNSEnabled6=false&IsDDNSEnabled7=false&IsDDNSEnabled4=false&IsDDNSEnabled5=false&IsDDNSEnabled2=false&IsDDNSEnabled3=false&IsDDNSEnabled1=false&RecordType22=TXT&Address8=challengetoken&Address9=challengetoken1&IsActive9=true&IsActive8=true&FriendlyName20=&MXPref21=10&FriendlyName22=&FriendlyName23=&IsActive3=true&IsActive2=true&IsActive1=true&IsActive7=true&IsActive6=true&IsActive5=true&IsActive4=true&TTL4=1800&Address22=challengetoken&AssociatedAppTitle23=&HostName12=_acme-challenge.test&HostName13=orig.nameonly.test&HostName10=_acme-challenge.listrecordset&HostName11=_acme-challenge.noop&HostName16=orig.testfqdn&HostName17=orig.testfull&HostName14=orig.nameonly.test&Address1=127.0.0.1&HostName18=random.fqdntest&HostName19=random.fulltest&MXPref5=10&FriendlyName21=&IsActive13=true&IsActive12=true&IsActive11=true&TTL3=1800&IsActive17=true&IsActive16=true&IsActive15=true&IsActive14=true&Address4=challengetoken1&IsActive19=true&IsActive18=true&MXPref2=10&MXPref1=10&Address7=challengetoken&TTL8=1800&TTL9=1800&MXPref9=10&MXPref8=10&MXPref7=10&TTL1=1800&TTL2=1799&Address3=docs.example.com.&MXPref3=10&TTL5=1800&TTL6=1800&TTL7=1800&TTL14=1800&RecordType24=TXT&TTL23=1800&Address13=challengetoken&TTL21=1800&TTL20=1800&HostName24=updated.testfull&TTL15=1800&TLD=com&FriendlyName10=&Address2=127.0.0.1&AssociatedAppTitle21=&AssociatedAppTitle20=&Address12=challengetoken&AssociatedAppTitle22=&MXPref22=10&Address18=challengetoken&TTL22=1800&Address19=challengetoken&AssociatedAppTitle12=&MXPref13=10&MXPref12=10&MXPref11=10&MXPref10=10&MXPref17=10&MXPref16=10&MXPref15=10&MXPref14=10&MXPref19=10&MXPref18=10&HostName1=localhost&HostName2=www&HostName3=docs&HostName4=_acme-challenge.createrecordset&HostName5=_acme-challenge.createrecordset&HostName6=_acme-challenge.deleterecordinset&HostName7=_acme-challenge.fqdn&HostName8=_acme-challenge.full&HostName9=_acme-challenge.listrecordset&Address10=challengetoken2&Address11=challengetoken&Address16=challengetoken&MXPref6=10&Address14=updated&Address15=challengetoken&TTL12=1800&TTL13=1800&HostName23=updated.testfull&HostName22=updated.testfqdn&HostName21=updated.test&HostName20=random.test&TTL10=1800&Address17=challengetoken&IsActive22=true&TTL11=1800&Address5=challengetoken2&IsActive23=true&TTL16=1800&FriendlyName16=&IsActive20=true&TTL17=1800&AssociatedAppTitle6=&AssociatedAppTitle7=&AssociatedAppTitle4=&FriendlyName2=&FriendlyName5=&FriendlyName4=&FriendlyName7=&AssociatedAppTitle1=&FriendlyName9=&FriendlyName8=&HostName15=orig.test&AssociatedAppTitle8=&AssociatedAppTitle9=&Address6=challengetoken2&SLD=example-aptise-2&MXPref4=10&Address24=challengetoken&Address23=challengetoken&TTL18=1800&Address21=challengetoken&Address20=challengetoken&AssociatedAppTitle18=&TTL19=1800&HostId14=524858&AssociatedAppTitle19=&HostId15=524203&HostId18=524200'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['4289']
+      Content-Type: [application/x-www-form-urlencoded]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.sandbox.namecheap.com/xml.response?ClientIP=127.0.0.1&Command=namecheap.domains.dns.setHosts
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n\
+        <ApiResponse Status=\"OK\" xmlns=\"http://api.namecheap.com/xml.response\"\
+        >\r\n  <Errors />\r\n  <Warnings />\r\n  <RequestedCommand>namecheap.domains.dns.sethosts</RequestedCommand>\r\
+        \n  <CommandResponse Type=\"namecheap.domains.dns.setHosts\">\r\n    <DomainDNSSetHostsResult\
+        \ Domain=\"example-aptise-2.com\" IsSuccess=\"true\">\r\n      <Warnings />\r\
+        \n    </DomainDNSSetHostsResult>\r\n  </CommandResponse>\r\n  <Server>PHX01SBAPI02</Server>\r\
+        \n  <GMTTimeDifference>--7:00</GMTTimeDifference>\r\n  <ExecutionTime>0.923</ExecutionTime>\r\
+        \n</ApiResponse>"}
+    headers:
+      cache-control: [private]
+      content-length: ['561']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Mon, 26 Mar 2018 17:46:23 GMT']
+      server: [Microsoft-IIS/8.5]
+      vary: [Accept-Encoding]
+      x-aspnet-version: [4.0.30319]
+      x-powered-by: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -29,6 +29,7 @@ self.provider_name must be set
 self.domain must be set
 self._filter_headers can be defined to provide a list of sensitive headers
 self._filter_query_parameters can be defined to provide a list of sensitive parameter
+self.provider_variant can be defined as a prefix for saving cassettes when a provider uses multiple variants
 
 
 Extended test suites can be skipped by adding the following snippet to the test_{PROVIDER_NAME}.py file
@@ -335,7 +336,20 @@ class IntegrationTests(object):
         return overrides
 
     def _cassette_path(self, fixture_subpath):
-        return "{0}/{1}".format(self.provider_name, fixture_subpath)
+        """
+        A path customized for the provider's fixture.
+        The default path is, for example:
+            {provider}/IntegrationTests
+        but if the test is a `provider_variant`, the path is customized to the variant:
+            {provider}/{variant_name}-IntegrationTests
+        """
+        if self.provider_variant:
+            return "{0}/{1}-{2}".format(self.provider_name, self.provider_variant, fixture_subpath)
+        else:
+            return "{0}/{1}".format(self.provider_name, fixture_subpath)
+
+    # optional. used to identify the test variant, if any.
+    provider_variant = None
 
     def _filter_headers(self):
         return []

--- a/tests/providers/test_namecheap.py
+++ b/tests/providers/test_namecheap.py
@@ -24,7 +24,7 @@ A note about running these tests against the live environment
     Namecheap acts a little differently for "owned" vs "managed" domains, so a
     secondary test run must be done.
 
-To set this up:
+To set enable live testing against the actual API:
 
 * Create two (2) Sandbox accounts on Namecheap
 * Using the First Account:

--- a/tests/providers/test_namecheap.py
+++ b/tests/providers/test_namecheap.py
@@ -64,7 +64,7 @@ class NamecheapProviderTests(TestCase, IntegrationTests):
             LEXICON_NAMECHEAP_DOMAIN
         """
         env_domain = os.environ.get('LEXICON_NAMECHEAP_DOMAIN', None)
-        return env_domain or 'lexicontest.com'
+        return env_domain or 'example-aptise.com'
 
     def _filter_query_parameters(self):
         return ['ApiKey','UserName', 'ApiUser']

--- a/tests/providers/test_namecheap.py
+++ b/tests/providers/test_namecheap.py
@@ -4,6 +4,50 @@ from lexicon.common.options_handler import env_auth_options
 from integration_tests import IntegrationTests
 from unittest import TestCase
 import pytest
+import os
+
+"""
+A note about running these tests against the live environment
+
+1.  Namecheap offers a Testing Sandbox for their API.
+    You must create an account on `sandbox.namecheap.com`, then "apply" for API
+    access. It is supposed to be issued automatically, but you will most-likely
+    need to ask their support to approve API access on the test system. You can
+    do this via their LiveChat
+
+    https://www.namecheap.com/support/api/methods.aspx
+
+2.  There are two variants of the test:
+    * NamecheapProviderTests
+    * NamecheapManagedProviderTests
+
+    Namecheap acts a little differently for "owned" vs "managed" domains, so a
+    secondary test run must be done.
+
+To set this up:
+
+* Create two (2) Sandbox accounts on Namecheap
+* Using the First Account:
+    *   Enable API access
+    *   "Purchase" a first test domain for use on `NamecheapProviderTests`.
+        This will be the env variable `LEXICON_NAMECHEAP_DOMAIN`
+* Using the Second Account:
+    *   "Purchase" a second test domain for use on `NamecheapManagedProviderTests`.
+        This will be the env variable `LEXICON_NAMECHEAP_DOMAINMANAGED`
+    *   Using the Namecheap dashboard, "share" the domain management with the
+        first user.
+*   The First account will then get an email to "accept" the domain management
+    invitation from the Second account.
+*   All API tests occure on the First account
+*   Note: Namecheap's API requires the client's IP address to be whitelisted.
+
+The required Environment Variables for a live test are:
+
+    export LEXICON_NAMECHEAP_TOKEN={TOKEN}
+    export LEXICON_NAMECHEAP_USERNAME={USERNAME}
+    export LEXICON_NAMECHEAP_DOMAIN={DOMAIN_1}
+    export LEXICON_NAMECHEAP_DOMAINMANAGED={DOMAIN_2}
+"""
 
 # Hook into testing framework by inheriting unittest.TestCase and reuse
 # the tests which *each and every* implementation of the interface must
@@ -12,7 +56,15 @@ class NamecheapProviderTests(TestCase, IntegrationTests):
 
     Provider = Provider
     provider_name = 'namecheap'
-    domain = 'lexicontest.com'
+
+    @property
+    def domain(self):
+        """
+        this can be used to override the tests
+            LEXICON_NAMECHEAP_DOMAIN
+        """
+        env_domain = os.environ.get('LEXICON_NAMECHEAP_DOMAIN', None)
+        return env_domain or 'lexicontest.com'
 
     def _filter_query_parameters(self):
         return ['ApiKey','UserName', 'ApiUser']
@@ -27,3 +79,26 @@ class NamecheapProviderTests(TestCase, IntegrationTests):
     @pytest.mark.skip(reason="can not set ttl when creating/updating records")
     def test_Provider_when_calling_list_records_after_setting_ttl(self):
         return
+
+
+class NamecheapManagedProviderTests(NamecheapProviderTests):
+    """
+    The Namecheap API behaves differently for domains that are "Managed" by an
+    account instead of "Owned" by the account.  Some endpoints won't work;
+    others return different data.
+
+    In orde to handle this, we run the tests on a second domain owned by another
+    namecheap customer, but permissioned to this account.
+    
+    Note we define a `provider_variant`, which will change the cassette path.
+    """
+    provider_variant = 'managed'
+
+    @property
+    def domain(self):
+        """
+        this can be used to override the tests
+            LEXICON_NAMECHEAP_DOMAINMANAGED
+        """
+        env_domain = os.environ.get('LEXICON_NAMECHEAP_DOMAINMANAGED', None)
+        return env_domain or 'example-aptise-2.com'


### PR DESCRIPTION
This replaces PR #205

This proposed PR handles the following issues:
* #191
* #172 

# Overview

* the namecheap `authenticate` method now calls the cloud endpoint `namecheap.domains.getInfo`, which will show information for a 'permissioned' domain or return an error document. Previously this called the `domains_getList` client method and iterated paginated results to find the domain, however that list only shows domains "owned" by a namecheap account, and does not include domains owned by a first account which have had permissions delegated to the second active account.

* the namecheap provider did not respect the TTL commandline arg. The new behavior is to inject a TTL from the commandline if provided and valid, otherwise leaving the TTL value blank (which will invoke the serverside default). Submitting a ttl outside the valid range for namecheap will raise a `ValueError`.

* the IntegrationTests object was extended with a `provider_variant` attribute, defaulted to `None`.  If present, this will change the cassette path from `{provider}/IntegrationTests` to `{provider}/{variant_name}-IntegrationTests`.  This approach allows for testing multiple domain scenarios for the same provider.

* the `NamecheapProviderTests` replaced a `domain` attribute with a `domain` property tied to the environment variable `LEXICON_NAMECHEAP_DOMAIN`. This will allow developers to test against the llive API without adjusting code.

* A variant of `NamecheapProviderTests` called `NamecheapManagedProviderTests` was added, which tests against a domain that is not owned, but managed, on the namecheap platform.

* The namecheap tests were documented with instructions on how to fully setup the test environment and create sandbox accounts in the cloud.