### PR TITLE
Make the PKG-INFO build reproducible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Get a list of all the providers
 current_filepath = path.join(here, 'lexicon', 'providers')
 providers = [path.splitext(f)[0] for f in listdir(current_filepath) if path.isfile(path.join(current_filepath, f))]
-providers = list(set(providers))
+providers = list(sorted(set(providers)))
 providers.remove('base')
 providers.remove('__init__')
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed that lexicon could not be built reproducibly.

This is due to iterating over the filesystem in a non-determistic order and populating the `Keywords` variable in `PKG-INFO` based on that.

This was originally filed in Debian as #894493 [1].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/894493

Signed-off-by: Chris Lamb <lamby@debian.org>