### PR TITLE
Constellix provider

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@ lexicon/providers/aurora.py 		@joostdebruijn
 lexicon/providers/cloudflare.py 	@analogj
 lexicon/providers/cloudns.py 		@ppmathis
 lexicon/providers/cloudxns.py 		@zh99998
+lexicon/providers/constellix.py 		@pmkane
 lexicon/providers/digitalocean.py	@analogj
 lexicon/providers/dnsimple.py		@analogj
 lexicon/providers/dnsmadeeasy.py	@analogj @nydr

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -24,7 +24,7 @@ import json
 import locale
 import logging
 import time
-from hashlib import sha1
+import hashlib
 
 import requests
 from builtins import bytes
@@ -228,7 +228,7 @@ class Provider(BaseProvider):
         # Date string in epoch format
         request_date = str(int(time.time() * 1000))
 
-        hashed = hmac.new(self.options['auth_token'], msg=request_date, digestmod=sha1)
+        hashed = hmac.new(self.options['auth_token'].encode('utf-8'), request_date.encode('utf-8'), digestmod=hashlib.sha1)
 
         default_headers['x-cnsdns-requestDate'] = request_date
         default_headers['x-cnsdns-hmac'] = base64.b64encode(hashed.digest())

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -107,6 +107,7 @@ class Provider(BaseProvider):
 
         if not identifier:
             existing = self._guess_record(type, name)
+            logger.error(existing)
             identifier = existing['id']
 
         if not identifier:
@@ -114,11 +115,13 @@ class Provider(BaseProvider):
 
         data = {
             'id': identifier,
-            'ttl': self.options['ttl']
+            'ttl': self.options['ttl'],
+            'name': self._relative_name(name)
         }
 
         if content:
-            data['value'] = content
+            data['roundRobin'] =  [{'disableFlag': False,
+                                    'value': content}]
 
         payload = self._put('/domains/{0}/records/{1}/{2}/'.format(self.domain_id, type, identifier), data)
 
@@ -169,12 +172,11 @@ class Provider(BaseProvider):
 
     def _guess_record(self, type, name=None, content=None):
         records = self.list_records(type=type, name=name, content=content)
-        if len(records) == 1:
-            return records[0]
-        elif len(records) > 1:
-            raise Exception('Identifier was not provided and several existing records match the request for {0}/{1}'.format(type,name))
-        elif len(records) == 0:
+
+        if len(records) == 0:
             raise Exception('Identifier was not provided and no existing records match the request for {0}/{1}'.format(type,name))    
+        else:
+            return records[0]
 
     def _request(self, action='GET',  url='/', data=None, query_params=None):
         if data is None:

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -136,7 +136,7 @@ class Provider(BaseProvider):
         logger.debug('delete_records: %s', delete_record_id)
         
         for record_id in delete_record_id:
-            payload = self._delete('/dns/managed/{0}/records/{1}'.format(self.domain_id, record_id))
+            payload = self._delete('/domains/{0}/records/{1}/{2}/'.format(self.domain_id, type, record_id))
 
         # is always True at this point, if a non 200 response is returned an error is raised.
         logger.debug('delete_record: %s', True)

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -74,10 +74,10 @@ class Provider(BaseProvider):
             filter['type'] = type
         if name:
             filter['recordName'] = self._relative_name(name)
-        payload = self._get('/dns/managed/{0}/records'.format(self.domain_id), filter)
+        payload = self._get('/domains/{0}/records/{1}/'.format(self.domain_id, type))
 
         records = []
-        for record in payload['data']:
+        for record in payload:
             processed_record = {
                 'type': record['type'],
                 'name': '{0}.{1}'.format(record['name'], self.options['domain']),

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -29,7 +29,6 @@ class Provider(BaseProvider):
         self.api_endpoint = self.engine_overrides.get('api_endpoint', 'https://api.dns.constellix.com/v1')
 
     def authenticate(self):
-
         try:
             payload = self._get('/domains/')
         except requests.exceptions.HTTPError as e:
@@ -37,13 +36,14 @@ class Provider(BaseProvider):
                 payload = {}
             else:
                 raise e
+    
+        for domain in payload:
+            if domain['name'] == self.options['domain']:
+                self.domain_id = domain['id']
+                continue
 
-        logger.debug("%s", payload)
-
-        if not payload or not payload['id']:
+        if not self.domain_id:
             raise Exception('No domain found')
-
-        self.domain_id = payload['id']
 
 
     # Create record. If record already exists with the same content, do nothing'

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -51,8 +51,10 @@ class Provider(BaseProvider):
     def create_record(self, type, name, content):
         record = {
             'name': self._relative_name(name),
-            'value': content,
-            'ttl': self.options['ttl']
+            'ttl': self.options['ttl'],
+            'roundRobin':
+                [{'disableFlag': False,
+                 'value': content}],
         }
         payload = {}
         try:

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -1,0 +1,169 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import base64
+import contextlib
+import hmac
+import json
+import locale
+import logging
+import time
+from hashlib import sha1
+
+import requests
+from builtins import bytes
+
+from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-api-key", help="specify the API key username used to authenticate")
+    subparser.add_argument("--auth-secret", help="specify secret key used authenticate=")
+
+class Provider(BaseProvider):
+
+    def __init__(self, options, engine_overrides=None):
+        super(Provider, self).__init__(options, engine_overrides)
+        self.domain_id = None
+        self.api_endpoint = self.engine_overrides.get('api_endpoint', 'https://api.dns.constellix.com/v1')
+
+    def authenticate(self):
+
+        try:
+            payload = self._get('/domains/')
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                payload = {}
+            else:
+                raise e
+
+        logger.debug("%s", payload)
+
+        if not payload or not payload['id']:
+            raise Exception('No domain found')
+
+        self.domain_id = payload['id']
+
+
+    # Create record. If record already exists with the same content, do nothing'
+    def create_record(self, type, name, content):
+        record = {
+            'type': type,
+            'name': self._relative_name(name),
+            'value': content,
+            'ttl': self.options['ttl']
+        }
+        payload = {}
+        try:
+            payload = self._post('/dns/managed/{0}/records/'.format(self.domain_id), record)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code != 400:
+                raise
+
+                # http 400 is ok here, because the record probably already exists
+        logger.debug('create_record: %s', 'name' in payload)
+        return True
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        filter = {}
+        if type:
+            filter['type'] = type
+        if name:
+            filter['recordName'] = self._relative_name(name)
+        payload = self._get('/dns/managed/{0}/records'.format(self.domain_id), filter)
+
+        records = []
+        for record in payload['data']:
+            processed_record = {
+                'type': record['type'],
+                'name': '{0}.{1}'.format(record['name'], self.options['domain']),
+                'ttl': record['ttl'],
+                'content': record['value'],
+                'id': record['id']
+            }
+
+            processed_record = self._clean_TXT_record(processed_record)
+            records.append(processed_record)
+
+        if content:
+            records = [record for record in records if record['content'].lower() == content.lower()]
+
+        logger.debug('list_records: %s', records)
+        return records
+
+    # Create or update a record.
+    def update_record(self, identifier, type=None, name=None, content=None):
+
+        data = {
+            'id': identifier,
+            'ttl': self.options['ttl']
+        }
+
+        if name:
+            data['name'] = self._relative_name(name)
+        if content:
+            data['value'] = content
+        if type:
+            data['type'] = type
+
+        payload = self._put('/dns/managed/{0}/records/{1}'.format(self.domain_id, identifier), data)
+
+        logger.debug('update_record: %s', True)
+        return True
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        delete_record_id = []
+        if not identifier:
+            records = self.list_records(type, name, content)
+            delete_record_id = [record['id'] for record in records]
+        else:
+            delete_record_id.append(identifier)
+        
+        logger.debug('delete_records: %s', delete_record_id)
+        
+        for record_id in delete_record_id:
+            payload = self._delete('/dns/managed/{0}/records/{1}'.format(self.domain_id, record_id))
+
+        # is always True at this point, if a non 200 response is returned an error is raised.
+        logger.debug('delete_record: %s', True)
+        return True
+
+
+    # Helpers
+
+    def _request(self, action='GET',  url='/', data=None, query_params=None):
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        default_headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'x-cnsdns-apiKey': self.options['auth_api_key'],
+        }
+        default_auth = None
+
+        # Date string in epoch format
+        request_date = str(int(time.time() * 1000))
+
+        hashed = hmac.new(self.options['auth_secret'], msg=request_date, digestmod=sha1)
+
+        default_headers['x-cnsdns-requestDate'] = request_date
+        default_headers['x-cnsdns-hmac'] = base64.b64encode(hashed.digest())
+
+        r = requests.request(action, self.api_endpoint + url, params=query_params,
+                             data=json.dumps(data),
+                             headers=default_headers,
+                             auth=default_auth)
+        r.raise_for_status()  # if the request fails for any reason, throw an error.
+
+        # PUT and DELETE actions dont return valid json.
+        if action == 'DELETE' or action == 'PUT':
+            return r.text
+        return r.json()

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:35Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":0,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:49 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=76E2A4A2D523D1618CE9972F9C610E43; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:35Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":0,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:49 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0EF293F502D522040E8F5246A8B0A6FC; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:35Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":0,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:50 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=830FF3C0F1B1955946F1841EC030EEE3; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "127.0.0.1"}],
+      "name": "localhost", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['96']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/A/
+  response:
+    body: {string: !!python/unicode '[{"id":92008,"type":"A","recordType":"a","name":"localhost","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997471178,"value":["127.0.0.1"],"roundRobin":[{"value":"127.0.0.1","disableFlag":false}],"geolocation":null,"roundRobinFailover":null}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:51 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=8893D8B469E9B0026AB3D922627F1769; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:51Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:51 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2DF0EA85E7DF2626614242A647D73783; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "docs.example.com"}],
+      "name": "docs", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['98']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/CNAME/
+  response:
+    body: {string: !!python/unicode '[{"id":92009,"type":"CNAME","recordType":"cname","name":"docs","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997472656,"value":"","roundRobin":[{"value":"","disableFlag":false}],"geolocation":null,"host":""}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:52 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=E121E69C338FB6149905BEA01C226EA0; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010104,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:52Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:53 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=EEBAD2F998A59AE6A3A0751877A66D73; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "_acme-challenge.fqdn", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474054,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:54 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=DA5CE3084FDB8D8F48C034929D53F68F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010105,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:54Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":3,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:54 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=E0CFC8236B723A1F1E8AD33F8239D742; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "_acme-challenge.full", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475401,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:55 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=20F1AF407059CAC1D9FB16D8044C799F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010106,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:55Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":4,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:56 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=D9C3E7BB485090D85E9CBDA2306C8163; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "_acme-challenge.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476719,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:56 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=D13A5BAAB4599BBF3A0A1325472FF44A; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,127 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:56Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":5,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:57 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=D96F580272094577245B549983D0CF18; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"}],
+      "name": "_acme-challenge.createrecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997478031,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:58 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=F540D62D4FB3B850D314C89A8CEE31C9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken2"}],
+      "name": "_acme-challenge.createrecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '{"errors":["\"TXT\" record with name \"_acme-challenge.createrecordset\"
+        in GTD Region \"Default\" of domain \"example.org\" already exists"]}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=utf-8]
+      date: ['Tue, 17 Apr 2018 20:37:58 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=B513ADA59577617F58A46ABA724F4B9C; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997478030,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:59 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=F51A490E2B52B12120EA1A27CA47E0AC; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"},
+      {"disableFlag": false, "value": "challengetoken2"}], "id": 92013, "name": "_acme-challenge.createrecordset",
+      "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['189']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92013/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:37:59 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=052886AB4E0D708661A4FB91D174B8A9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,125 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010109,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:37:59Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":7,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:00 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=C81E86F4A41F3732100D3ECEF49CCC9A; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "_acme-challenge.noop", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481112,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:01 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=CE153B4DF465C9136670A3A3CF662710; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "_acme-challenge.noop", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['112']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '{"errors":["\"TXT\" record with name \"_acme-challenge.noop\"
+        in GTD Region \"Default\" of domain \"example.org\" already exists"]}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=utf-8]
+      date: ['Tue, 17 Apr 2018 20:38:01 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=22B4D0A8E6BFBEDE1D15337561CE7B33; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:02 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=977F066B50617D307545D3C26E865089; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:02 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=27D29D706986A1DB7643991FCB720C25; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010110,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:01Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":8,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:03 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=89AC23EE160B56B570F983EDD82E6F39; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "delete.testfilt", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92017,"type":"TXT","recordType":"txt","name":"delete.testfilt","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997484139,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:04 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=DB999C94D82047428731563B3AC600A6; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92017,"type":"TXT","recordType":"txt","name":"delete.testfilt","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997484138,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:04 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0268F26E920E8A105D165833556D4DF4; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92017/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  deleted successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:05 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=E663ED775C0CB1FCFCCDA6CF92FBF889; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:05 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=4C604CC082E8126428EA902C1E20D459; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010112,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":10,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:06 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A204E55BBFCB79C73B8C7AF52A46FFA3; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "delete.testfqdn", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92018,"type":"TXT","recordType":"txt","name":"delete.testfqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997487213,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:07 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=AC73597220658E7D9C5382A2AE4604E5; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92018,"type":"TXT","recordType":"txt","name":"delete.testfqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997487212,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:07 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=D953919A272688F2612A35D36E92AD73; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92018/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  deleted successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:08 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=7FBAF55B9F59F4094D147FB462B93039; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:08 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=45747F4B731C9EF7D447F5D222EEC8F5; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010114,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:08Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":12,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:09 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=211B00E9FF1E976F9D7E427E1AE2696E; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "delete.testfull", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92019,"type":"TXT","recordType":"txt","name":"delete.testfull","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997490233,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:10 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=7388A7CD8099CF83AA57816F09739B2D; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92019,"type":"TXT","recordType":"txt","name":"delete.testfull","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997490232,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:10 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2A032777092AE2A3FF3D19C91E8BDB64; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92019/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  deleted successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:11 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=E2B0118C950B93333415131EA29494D9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:11 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=1A46F3EF5DFD74B5E438E722526DE7E1; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010116,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:11Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":14,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:12 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=3CE2957A81DD35C6B122692E8444C1F6; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "delete.testid", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92020,"type":"TXT","recordType":"txt","name":"delete.testid","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997493398,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:13 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=98D19586CC0A796C9B20B2ED0BC0B368; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92020,"type":"TXT","recordType":"txt","name":"delete.testid","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997493397,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:13 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0C9A257D0FDE38D66975D97849C227CC; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92020,"type":"TXT","recordType":"txt","name":"delete.testid","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997493397,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92009,"type":"CNAME","recordType":"cname","name":"docs","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997472655,"value":"","roundRobin":[{"value":"","disableFlag":false}],"pools":[],"poolsDetail":[],"geolocation":null,"host":""},{"id":92008,"type":"A","recordType":"a","name":"localhost","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997471177,"value":["127.0.0.1"],"roundRobin":[{"value":"127.0.0.1","disableFlag":false}],"geolocation":null,"roundRobinFailover":[],"pools":[],"poolsDetail":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:14 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=7E0DED19ABE57B8E8623FA4D1D8E3321; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92020/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  deleted successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:15 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=AA0C86DB03A49CF78C43EA1043AA95A9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:15 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=47CB6E1A601F7B91C35EAB633A3DC284; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010118,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:15Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":16,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:16 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=8354D6B1011A6E16722824C9F6B1B1C6; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"}],
+      "name": "_acme-challenge.deleterecordinset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['126']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997496943,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:17 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=D80934C2C889DF7FC739A9ACEA8E7E72; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken2"}],
+      "name": "_acme-challenge.deleterecordinset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['126']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '{"errors":["\"TXT\" record with name \"_acme-challenge.deleterecordinset\"
+        in GTD Region \"Default\" of domain \"example.org\" already exists"]}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=utf-8]
+      date: ['Tue, 17 Apr 2018 20:38:17 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=39F5D5040CDA1F3E07AF63D6087C2152; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997496942,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:18 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=F446F829AF937671F163BEAAD0F7B4CD; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"},
+      {"disableFlag": false, "value": "challengetoken2"}], "id": 92021, "name": "_acme-challenge.deleterecordinset",
+      "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['191']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92021/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:18 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=944BEBC1D4EA49BA6EB387856FB59501; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997498628,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:19 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=E5670EFEA9C42189E1CECB782A66D9E2; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken2"}],
+      "id": 92021, "name": "_acme-challenge.deleterecordinset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['139']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92021/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:19 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=93B636BCD471D6527BA67513902BF0CB; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:20 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=94446459D72972A886C830A266BB9329; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,199 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010121,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:19Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":19,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:21 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=CFC62744B56E3644E1BF2B084A27DF63; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"}],
+      "name": "_acme-challenge.deleterecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92023,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997501753,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:21 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=358DBA73406AF0ABF3526AA4F2D26CC4; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken2"}],
+      "name": "_acme-challenge.deleterecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['124']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '{"errors":["\"TXT\" record with name \"_acme-challenge.deleterecordset\"
+        in GTD Region \"Default\" of domain \"example.org\" already exists"]}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=utf-8]
+      date: ['Tue, 17 Apr 2018 20:38:22 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=3F1E01EE7A82C3E8FC6DB295840C4163; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92023,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997501752,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:22 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=F5846EB71DA3FC5B67FEE70FA827770E; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"},
+      {"disableFlag": false, "value": "challengetoken2"}], "id": 92023, "name": "_acme-challenge.deleterecordset",
+      "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['189']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92023/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:23 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=61608C3A233949C9D955C0174BB0B26C; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92023,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997503421,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:24 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=6951BD1F116648211A84911C0C1BCF7C; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92023/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  deleted successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:24 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2CF005CE573DC3FC47DAA8468F6323F9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:25 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=6094E0EF3BC20C14E30074F312D2DFE2; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010124,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:24Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":22,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:25 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2C7CBC832BF60E9A10CCE619AAB3164B; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "ttlshouldbe3600"}],
+      "name": "ttl.fqdn", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506672,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:26 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0581D10B9E7C91B2DA0F8CAF1E92F33F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:27 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A6298132397E5C3852BE1A74B8778179; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,151 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010125,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:26Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":23,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:28 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=9EA7DFB7FA9F1DB3BE13EE818DE6B86D; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"}],
+      "name": "_acme-challenge.listrecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['122']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997508562,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:28 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=CF8C67F55F0767A868A69841F45604F9; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken2"}],
+      "name": "_acme-challenge.listrecordset", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['122']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '{"errors":["\"TXT\" record with name \"_acme-challenge.listrecordset\"
+        in GTD Region \"Default\" of domain \"example.org\" already exists"]}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=utf-8]
+      date: ['Tue, 17 Apr 2018 20:38:29 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=B8FAA55E4622139417C59E6F2FDB8729; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 400, message: Bad Request}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997508561,"value":[{"value":"\"challengetoken1\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:29 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=009016B76EBB11BCA222EBA9D65E738F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken1"},
+      {"disableFlag": false, "value": "challengetoken2"}], "id": 92026, "name": "_acme-challenge.listrecordset",
+      "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['187']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92026/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:30 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=384963BDC44EB8A0BBBE290DFA1F2A00; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:30 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=FA2722A9E66FE68D3DEE620FBC90B791; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010127,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:30Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":25,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:31 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=1548DB1A94BE263A2F7AEB6A087D8A62; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "random.fqdntest", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512387,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:32 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2E18FCCCD75408BF901568621AFB1792; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:32 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=7D14DF3FFD9AC183CBCDBDC5F3849CD3; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010128,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:32Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":26,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:33 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=21FB75047C6E39F28C7852010A7E7914; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "random.fulltest", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['107']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514301,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:34 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=127ECBE15D49174D856172A5D007967C; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:34 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0F404FE5563DF42EEF875B30121AE3A0; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010129,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:34Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":27,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:35 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=2F2A10365DFA478C720670C8F9DBA2C7; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:36 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=984DEF034D1B652E300431DD5D754926; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010129,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:34Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":27,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:36 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A78EB93951C3D0B770F80809D2BEE37A; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "random.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['103']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517622,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:37 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0AFBF416389A1C9A3774A901CFEAF6D2; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:38 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=788528209F1D3B454EFF25DBB6279DF6; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010130,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:37Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":28,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:38 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A77CAF18C66477A7DA6A93972EA94FCA; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92009,"type":"CNAME","recordType":"cname","name":"docs","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997472655,"value":"","roundRobin":[{"value":"","disableFlag":false}],"pools":[],"poolsDetail":[],"geolocation":null,"host":""},{"id":92008,"type":"A","recordType":"a","name":"localhost","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997471177,"value":["127.0.0.1"],"roundRobin":[{"value":"127.0.0.1","disableFlag":false}],"geolocation":null,"roundRobinFailover":[],"pools":[],"poolsDetail":[]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:39 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=68054D822D874444DCBEDC67CEC3145F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010130,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:37Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":28,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:40 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=3E71EC941452D03BB3B74CE569E31444; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "orig.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92031,"type":"TXT","recordType":"txt","name":"orig.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997520842,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:40 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=5F7AD47B224D5D39E21E9584085AB8EA; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92031,"type":"TXT","recordType":"txt","name":"orig.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997520840,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:41 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=BB48A1C076B3C0467541A73628A3C25F; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "id": 92031, "name": "updated.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['117']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92031/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:42 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=0545CBB1310A2392BA02C1D639490D79; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010132,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:42Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":30,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:42 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=6B4AEB2551C2757984E6427C8F7FF0B5; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "orig.nameonly.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['110']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92032,"type":"TXT","recordType":"txt","name":"orig.nameonly.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997523588,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:43 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=C334FDDF70E04259A69DD8C6DF95EAEB; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92032,"type":"TXT","recordType":"txt","name":"orig.nameonly.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997523587,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]},{"id":92031,"type":"TXT","recordType":"txt","name":"updated.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997522068,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:44 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=28F6DC73ED22BB0CE043B8FDC084B183; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "updated"}],
+      "id": 92032, "name": "orig.nameonly.test", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92032/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:44 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=941C7C231108E2B1A0BF4459151931B4; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010134,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:44Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":32,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:45 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=786D1C277CE5E34AC48A3E7F0589E6DA; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "orig.testfqdn", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92033,"type":"TXT","recordType":"txt","name":"orig.testfqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997526126,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:46 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=AB3A251324E3CCE12FE9117AB13EB3CE; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92032,"type":"TXT","recordType":"txt","name":"orig.nameonly.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997524721,"value":[{"value":"\"updated\"","disableFlag":false}],"roundRobin":[{"value":"\"updated\"","disableFlag":false}]},{"id":92033,"type":"TXT","recordType":"txt","name":"orig.testfqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997526125,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]},{"id":92031,"type":"TXT","recordType":"txt","name":"updated.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997522068,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:46 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=A6FEAFC2FBEFDE9835FFEED8CC940B72; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "id": 92033, "name": "updated.testfqdn", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92033/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:47 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=F2ADB4231D05A2FAC9E6AD2BFB21A488; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/constellix/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/
+  response:
+    body: {string: !!python/unicode '[{"id":23906,"name":"example.org","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010136,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-17T20:37:35Z","modifiedTs":"2018-04-17T20:38:47Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":34,"status":"ACTIVE","tags":[],"contactIds":[]},{"id":20063,"name":"actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010107,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-15T03:39:50Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":6,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20064,"name":"dk.actionkit.com","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010103,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-03-28T15:56:03Z","modifiedTs":"2018-04-05T15:11:13Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":2,"status":"ACTIVE","tags":null,"contactIds":[]},{"id":20234,"name":"actionk.it","soa":{"primaryNameserver":"ns11.constellix.com.","email":"dns.constellix.com.","ttl":86400,"serial":2015010102,"refresh":43200,"retry":3600,"expire":1209600,"negCache":180},"createdTs":"2018-04-03T04:35:04Z","modifiedTs":"2018-04-03T04:35:05Z","typeId":1,"domainTags":[],"folder":null,"hasGtdRegions":false,"hasGeoIP":false,"nameserverGroup":1,"nameservers":["ns11.constellix.com.","ns21.constellix.com.","ns31.constellix.com.","ns41.constellix.net.","ns51.constellix.net.","ns61.constellix.net."],"note":"","version":1,"status":"ACTIVE","tags":null,"contactIds":[]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:48 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=B35E3616C3FC52DEFEA83B99FE168EE7; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "name": "orig.testfull", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['105']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92034,"type":"TXT","recordType":"txt","name":"orig.testfull","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997528637,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:48 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=437F834456CBA249A20FFCFC1F2041CA; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/
+  response:
+    body: {string: !!python/unicode '[{"id":92013,"type":"TXT","recordType":"txt","name":"_acme-challenge.createrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997479715,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92021,"type":"TXT","recordType":"txt","name":"_acme-challenge.deleterecordinset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997499772,"value":[{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92010,"type":"TXT","recordType":"txt","name":"_acme-challenge.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997474053,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92011,"type":"TXT","recordType":"txt","name":"_acme-challenge.full","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997475400,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92026,"type":"TXT","recordType":"txt","name":"_acme-challenge.listrecordset","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997510237,"value":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken1\"","disableFlag":false},{"value":"\"challengetoken2\"","disableFlag":false}]},{"id":92015,"type":"TXT","recordType":"txt","name":"_acme-challenge.noop","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997481111,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92012,"type":"TXT","recordType":"txt","name":"_acme-challenge.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997476718,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92032,"type":"TXT","recordType":"txt","name":"orig.nameonly.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997524721,"value":[{"value":"\"updated\"","disableFlag":false}],"roundRobin":[{"value":"\"updated\"","disableFlag":false}]},{"id":92034,"type":"TXT","recordType":"txt","name":"orig.testfull","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997528636,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92028,"type":"TXT","recordType":"txt","name":"random.fqdntest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997512386,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92029,"type":"TXT","recordType":"txt","name":"random.fulltest","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997514300,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92030,"type":"TXT","recordType":"txt","name":"random.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997517621,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92025,"type":"TXT","recordType":"txt","name":"ttl.fqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997506671,"value":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}],"roundRobin":[{"value":"\"ttlshouldbe3600\"","disableFlag":false}]},{"id":92031,"type":"TXT","recordType":"txt","name":"updated.test","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997522068,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]},{"id":92033,"type":"TXT","recordType":"txt","name":"updated.testfqdn","recordOption":"roundRobin","noAnswer":false,"note":"","ttl":3600,"gtdRegion":1,"parentId":23906,"parent":"domain","source":"Domain","modifiedTs":1523997527258,"value":[{"value":"\"challengetoken\"","disableFlag":false}],"roundRobin":[{"value":"\"challengetoken\"","disableFlag":false}]}]'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:49 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=43910F1C123D009B98197E520399E749; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"roundRobin": [{"disableFlag": false, "value": "challengetoken"}],
+      "id": 92034, "name": "updated.testfull", "ttl": 3600}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['121']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.dns.constellix.com/v1/domains/23906/records/TXT/92034/
+  response:
+    body: {string: !!python/unicode '{"success":"Record  updated successfully"}'}
+    headers:
+      connection: [keep-alive]
+      content-type: [application/json;charset=UTF-8]
+      date: ['Tue, 17 Apr 2018 20:38:50 GMT']
+      requestlimitheader: ['300']
+      requestsremainingheader: ['299']
+      server: [Apache-Coyote/1.1]
+      set-cookie: [JSESSIONID=BEF98AD21A0225CBEFB244D57FD1EE4D; Path=/; HttpOnly]
+      transfer-encoding: [chunked]
+      x-application-context: ['application:production']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_constellix.py
+++ b/tests/providers/test_constellix.py
@@ -1,0 +1,17 @@
+from lexicon.providers.constellix import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+# Constellix does not currently have a sandbox and they enforce domain
+# uniqueness across the service.  You'll need your own production credentials
+# and a unique domain name if you want to run these tests natively.
+class ConstellixProviderTests(TestCase, IntegrationTests):
+
+    Provider = Provider
+    provider_name = 'constellix'
+    domain = 'example.org'
+
+    def _filter_headers(self):
+        return ['x-cnsdns-apiKey', 'x-cnsdns-hmac']
+

--- a/tests/providers/test_constellix.py
+++ b/tests/providers/test_constellix.py
@@ -7,7 +7,6 @@ import pytest
 # uniqueness across the service.  You'll need your own production credentials
 # and a unique domain name if you want to run these tests natively.
 class ConstellixProviderTests(TestCase, IntegrationTests):
-
     Provider = Provider
     provider_name = 'constellix'
     domain = 'example.org'

--- a/tests/providers/test_constellix.py
+++ b/tests/providers/test_constellix.py
@@ -12,5 +12,5 @@ class ConstellixProviderTests(TestCase, IntegrationTests):
     domain = 'example.org'
 
     def _filter_headers(self):
-        return ['x-cnsdns-apiKey', 'x-cnsdns-hmac']
+        return ['x-cnsdns-apiKey', 'x-cnsdns-hmac', 'x-cnsdns-requestDate']
 


### PR DESCRIPTION
Adds support for Constellix as a provider.

Constellix's API is not fully CRUD-y, so we have to jump through some hoops here, particularly around working with record sets. I've documented the limitations in lexicon/providers/constellix.py.