### PR TITLE
Added provider for Linode v4 API

### DIFF
--- a/lexicon/providers/linode4.py
+++ b/lexicon/providers/linode4.py
@@ -1,0 +1,159 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import json
+import logging
+
+import requests
+
+from .base import Provider as BaseProvider
+
+logger = logging.getLogger(__name__)
+
+def ProviderParser(subparser):
+    subparser.add_argument("--auth-token", help="specify api key used authenticate to DNS provider")
+
+class Provider(BaseProvider):
+    
+    def __init__(self, options, engine_overrides=None):
+        super(Provider, self).__init__(options, engine_overrides)
+        self.domain_id = None
+        self.api_endpoint = self.engine_overrides.get('api_endpoint', 'https://api.linode.com/v4/')
+
+    def authenticate(self):
+        self.domain_id = None
+        payload = self._get('domains', query_params={
+            'filter': {
+                'domain': self.options['domain']
+            }
+        })
+        if len(payload['data']) > 0:
+            self.domain_id = payload['data'][0]['id']
+        if self.domain_id == None:
+            raise Exception('Domain not found')
+
+    def create_record(self, type, name, content):
+        if len(self.list_records(type, name, content)) == 0:
+            if name:
+                name = self._relative_name(name)
+            
+            self._post('domains/{0}/records'.format(self.domain_id), data={
+                'name': name,
+                'type': type,
+                'target': content,
+                'ttl_sec': 0
+            })
+
+        return True
+    
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        resources_url = "domains/{0}/records".format(self.domain_id)
+        
+        if name:
+            name = self._relative_name(name)
+        
+        processed_records = []
+        
+        payload = self._get(resources_url)
+        for page in range(1, payload['pages'] + 1, 1):
+            if page > 1:
+                payload = self._get(resources_url, query_params={
+                    'page': page
+                })
+            
+            resource_list = payload['data']
+            if type:
+                resource_list = [resource for resource in resource_list if resource['type'] == type]
+            if name:
+                resource_list = [resource for resource in resource_list if self._relative_name(resource['name']) == name]
+            if content:
+                resource_list = [resource for resource in resource_list if resource['target'] == content]
+            
+            for resource in resource_list:
+                record_name = self._full_name(resource['name'])
+                if record_name.startswith('.'):
+                    record_name = record_name[1:]
+                
+                processed_records.append({
+                    'id': resource['id'],
+                    'type': resource['type'],
+                    'name': self._full_name(resource['name']),
+                    'ttl': resource['ttl_sec'],
+                    'content': resource['target']
+                })
+        
+        logger.debug('list_records: %s', processed_records)
+        return processed_records
+    
+    # Create or update a record.
+    def update_record(self, identifier, type=None, name=None, content=None):
+        if not identifier:
+            resources = self.list_records(type, name, None)
+            identifier = resources[0]['id'] if len(resources) > 0 else None
+        
+        logger.debug('update_record: %s', identifier)
+        
+        if name:
+            name = self._relative_name(name)
+        
+        url = 'domains/{0}/records/{1}'.format(self.domain_id, identifier)
+        self._put(url, data={
+            'name': name.lower() if name else None,
+            'type': type if type else None,
+            'target': content if content else None
+        })
+        
+        return True
+    
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        delete_resource_id = []
+        if not identifier:
+            resources = self.list_records(type, name, content)
+            delete_resource_id = [resource['id'] for resource in resources]
+        else:
+            delete_resource_id.append(identifier)
+        
+        logger.debug('delete_records: %s', delete_resource_id)
+        
+        for resource_id in delete_resource_id:
+            self._delete('domains/{0}/records/{1}'.format(
+                self.domain_id,
+                resource_id
+            ))
+        
+        return True
+
+    # Helpers
+    def _request(self, action='GET',  url='', data=None, query_params=None):
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        default_headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer {0}'.format(self.options.get('auth_token'))
+        }
+        
+        request_filter = query_params['filter'] if 'filter' in query_params else None
+        if request_filter is not None:
+            default_headers['X-Filter'] = json.dumps(request_filter)
+            del query_params['filter']
+        
+        request_url = "{0}{1}".format(self.api_endpoint, url)
+        
+        r = requests.request(action, request_url, params=query_params,
+                             data=json.dumps(data),
+                             headers=default_headers)
+        r.raise_for_status()  # if the request fails for any reason, throw an error.
+        if action == 'DELETE':
+            return ''
+        else:
+            result = r.json()
+            return result
+

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:10 GMT']
+      retry-after: ['98']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "thisisadomainidonotown.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"data": [], "page": 1, "pages": 1, "results":
+        0}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['49']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:11 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:14 GMT']
+      retry-after: ['87']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [], "results":
+        0}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['49']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:16 GMT']
+      retry-after: ['89']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "A", "name": "localhost", "target":
+      "127.0.0.1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1", "port":
+        0, "type": "A", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['173']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:17 GMT']
+      retry-after: ['113']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,132 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"data": [{"expire_sec": 0, "axfr_ips": [], "id":
+        1065421, "domain": "lexicon-test.com", "description": "", "refresh_sec": 0,
+        "soa_email": "contact@lexicon.com", "group": "", "retry_sec": 0, "status":
+        "active", "type": "master", "ttl_sec": 0, "master_ips": []}], "page": 1, "pages":
+        1, "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:19 GMT']
+      retry-after: ['111']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['222']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:20 GMT']
+      retry-after: ['81']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "CNAME", "name": "docs", "target":
+      "docs.example.com"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['77']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295233, "weight": 0, "name": "docs", "target": "docs.example.com",
+        "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['179']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:22 GMT']
+      retry-after: ['118']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"data": [{"expire_sec": 0, "axfr_ips": [], "id":
+        1065421, "domain": "lexicon-test.com", "description": "", "refresh_sec": 0,
+        "soa_email": "contact@lexicon.com", "group": "", "retry_sec": 0, "status":
+        "active", "type": "master", "ttl_sec": 0, "master_ips": []}], "page": 1, "pages":
+        1, "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:23 GMT']
+      retry-after: ['117']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 2, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['403']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:25 GMT']
+      retry-after: ['76']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.fqdn",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295234, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['191']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:26 GMT']
+      retry-after: ['82']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,136 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:28 GMT']
+      retry-after: ['80']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 3, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['596']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:29 GMT']
+      retry-after: ['78']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.full",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295236, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "_acme-challenge.full", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['191']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:31 GMT']
+      retry-after: ['77']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,139 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:32 GMT']
+      retry-after: ['75']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 4}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['789']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:33 GMT']
+      retry-after: ['107']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.test",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295237, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['191']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:35 GMT']
+      retry-after: ['70']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,238 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:36 GMT']
+      retry-after: ['69']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 5, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['982']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:38 GMT']
+      retry-after: ['69']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.createrecordset",
+      "target": "challengetoken1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset", "target":
+        "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['203']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:40 GMT']
+      retry-after: ['90']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 6, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1187']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:41 GMT']
+      retry-after: ['66']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.createrecordset",
+      "target": "challengetoken2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "_acme-challenge.createrecordset", "id":
+        9295239, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port":
+        0, "priority": 0, "target": "challengetoken2", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['203']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:43 GMT']
+      retry-after: ['64']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,267 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"data": [{"expire_sec": 0, "axfr_ips": [], "id":
+        1065421, "domain": "lexicon-test.com", "description": "", "refresh_sec": 0,
+        "soa_email": "contact@lexicon.com", "group": "", "retry_sec": 0, "status":
+        "active", "type": "master", "ttl_sec": 0, "master_ips": []}], "page": 1, "pages":
+        1, "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:44 GMT']
+      retry-after: ['96']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 7}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1392']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:46 GMT']
+      retry-after: ['62']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.noop",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['89']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "_acme-challenge.noop", "id": 9295240,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['191']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:47 GMT']
+      retry-after: ['54']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}], "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:49 GMT']
+      retry-after: ['59']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 8, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:50 GMT']
+      retry-after: ['51']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,310 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:52 GMT']
+      retry-after: ['49']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 8, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:53 GMT']
+      retry-after: ['48']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "delete.testfilt",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295241, "weight": 0, "name": "delete.testfilt", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['186']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:55 GMT']
+      retry-after: ['85']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 9, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "delete.testfilt", "id": 9295241, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1773']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:56 GMT']
+      retry-after: ['45']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295241
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:58 GMT']
+      retry-after: ['43']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:42:59 GMT']
+      retry-after: ['71']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,311 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:00 GMT']
+      retry-after: ['45']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}], "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:02 GMT']
+      retry-after: ['43']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "delete.testfqdn",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295242, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "delete.testfqdn", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['186']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:05 GMT']
+      retry-after: ['40']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295242, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "delete.testfqdn", "ttl_sec": 0,
+        "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}], "results":
+        9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1773']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:06 GMT']
+      retry-after: ['39']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295242
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:07 GMT']
+      retry-after: ['63']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:09 GMT']
+      retry-after: ['61']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,310 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:10 GMT']
+      retry-after: ['38']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}], "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:12 GMT']
+      retry-after: ['33']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "delete.testfull",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295243, "weight": 0, "name": "delete.testfull", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['186']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:13 GMT']
+      retry-after: ['67']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 9, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "delete.testfull", "id": 9295243, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1773']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:15 GMT']
+      retry-after: ['26']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['389']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295243
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:16 GMT']
+      retry-after: ['29']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 8, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:18 GMT']
+      retry-after: ['29']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,311 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:19 GMT']
+      retry-after: ['28']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}], "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:21 GMT']
+      retry-after: ['27']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "delete.testid",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['82']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "delete.testid", "id": 9295244, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['184']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:22 GMT']
+      retry-after: ['19']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['388']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295244, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "delete.testid", "ttl_sec": 0,
+        "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}], "results":
+        9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1771']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:24 GMT']
+      retry-after: ['24']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295244
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:25 GMT']
+      retry-after: ['45']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}], "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:27 GMT']
+      retry-after: ['21']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['389']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,423 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:28 GMT']
+      retry-after: ['19']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 8}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1585']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:30 GMT']
+      retry-after: ['50']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.deleterecordinset",
+      "target": "challengetoken1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['103']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "_acme-challenge.deleterecordinset",
+        "id": 9295246, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['205']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:31 GMT']
+      retry-after: ['16']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257828']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295246, "target": "challengetoken1",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1792']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:33 GMT']
+      retry-after: ['15']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['388']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.deleterecordinset",
+      "target": "challengetoken2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['103']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['205']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:34 GMT']
+      retry-after: ['11']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['389']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295246, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken1",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295247, "weight": 0, "name": "_acme-challenge.deleterecordinset",
+        "target": "challengetoken2", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 10}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2000']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:35 GMT']
+      retry-after: ['45']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295246
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:37 GMT']
+      retry-after: ['4']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['387']
+      x-ratelimit-reset: ['1525257822']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1792']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:38 GMT']
+      retry-after: ['7']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['388']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,468 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:40 GMT']
+      retry-after: ['8']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['387']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1792']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:42 GMT']
+      retry-after: ['6']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['386']
+      x-ratelimit-reset: ['1525257829']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.deleterecordset",
+      "target": "challengetoken1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295248, "target": "challengetoken1",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['203']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:44 GMT']
+      retry-after: ['1']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['387']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295248, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.deleterecordset", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}], "results": 10}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1998']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:45 GMT']
+      retry-after: ['0']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['386']
+      x-ratelimit-reset: ['1525257826']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.deleterecordset",
+      "target": "challengetoken2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['101']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295250, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['203']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:47 GMT']
+      retry-after: ['118']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 11, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.deleterecordset",
+        "id": 9295248, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordset", "id": 9295250, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2203']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:48 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295248
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:50 GMT']
+      retry-after: ['117']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: DELETE
+    uri: https://api.linode.com/v4/domains/1065421/records/9295250
+  response:
+    body: {string: !!python/unicode '{}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:51 GMT']
+      retry-after: ['19']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 9, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1792']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:53 GMT']
+      retry-after: ['114']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,328 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:54 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 9}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1792']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:56 GMT']
+      retry-after: ['117']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.listrecordset",
+      "target": "challengetoken1"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['99']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295251, "target": "challengetoken1",
+        "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['201']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:57 GMT']
+      retry-after: ['108']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295247, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295251, "weight": 0, "name": "_acme-challenge.listrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}], "page": 1, "pages": 1, "results": 10}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['1996']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:43:58 GMT']
+      retry-after: ['22']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "_acme-challenge.listrecordset",
+      "target": "challengetoken2"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['99']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "_acme-challenge.listrecordset", "id":
+        9295252, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port":
+        0, "priority": 0, "target": "challengetoken2", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['201']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:00 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295247, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295251, "weight": 0, "name": "_acme-challenge.listrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295252, "weight":
+        0, "name": "_acme-challenge.listrecordset", "target": "challengetoken2", "port":
+        0, "type": "TXT", "ttl_sec": 0, "protocol": null}], "page": 1, "pages": 1,
+        "results": 11}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2199']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:01 GMT']
+      retry-after: ['9']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257851']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:03 GMT']
+      retry-after: ['102']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 11, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2199']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:05 GMT']
+      retry-after: ['114']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "random.fqdntest",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "random.fqdntest", "id": 9295253, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['186']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:06 GMT']
+      retry-after: ['113']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295251, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.listrecordset", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295252, "target":
+        "challengetoken2", "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295253, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "random.fqdntest", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}], "results": 12}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2387']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:08 GMT']
+      retry-after: ['97']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,231 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:09 GMT']
+      retry-after: ['98']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295251, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.listrecordset", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295252, "target":
+        "challengetoken2", "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295253, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "random.fqdntest", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}], "results": 12}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2387']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:11 GMT']
+      retry-after: ['102']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "random.fulltest",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['84']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295254, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "random.fulltest", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['186']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:12 GMT']
+      retry-after: ['101']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 13, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2575']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:14 GMT']
+      retry-after: ['105']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,120 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:15 GMT']
+      retry-after: ['92']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295251, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.listrecordset", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295252, "target":
+        "challengetoken2", "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295253, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "random.fqdntest", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295254, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "random.fulltest", "ttl_sec": 0,
+        "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}], "results":
+        13}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2575']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:17 GMT']
+      retry-after: ['96']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:18 GMT']
+      retry-after: ['89']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 13, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2575']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:19 GMT']
+      retry-after: ['88']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "random.test", "target":
+      "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['80']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295255, "weight": 0, "name": "random.test", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['182']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:21 GMT']
+      retry-after: ['0']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257861']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295247, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295251, "weight": 0, "name": "_acme-challenge.listrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295252, "weight":
+        0, "name": "_acme-challenge.listrecordset", "target": "challengetoken2", "port":
+        0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295253, "weight": 0, "name": "random.fqdntest",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295254, "weight":
+        0, "name": "random.fulltest", "target": "challengetoken", "port": 0, "type":
+        "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null, "service":
+        null, "id": 9295255, "weight": 0, "name": "random.test", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}], "page": 1, "pages":
+        1, "results": 14}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2759']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:22 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525257982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,121 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"results": 1, "pages": 1, "data": [{"domain":
+        "lexicon-test.com", "master_ips": [], "type": "master", "ttl_sec": 0, "expire_sec":
+        0, "status": "active", "retry_sec": 0, "axfr_ips": [], "group": "", "soa_email":
+        "contact@lexicon.com", "id": 1065421, "refresh_sec": 0, "description": ""}],
+        "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:24 GMT']
+      retry-after: ['83']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 14, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "random.test", "id": 9295255, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2759']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:25 GMT']
+      retry-after: ['94']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,282 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"data": [{"expire_sec": 0, "axfr_ips": [], "id":
+        1065421, "domain": "lexicon-test.com", "description": "", "refresh_sec": 0,
+        "soa_email": "contact@lexicon.com", "group": "", "retry_sec": 0, "status":
+        "active", "type": "master", "ttl_sec": 0, "master_ips": []}], "page": 1, "pages":
+        1, "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:27 GMT']
+      retry-after: ['114']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525257982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295247, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295251, "weight": 0, "name": "_acme-challenge.listrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295252, "weight":
+        0, "name": "_acme-challenge.listrecordset", "target": "challengetoken2", "port":
+        0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295253, "weight": 0, "name": "random.fqdntest",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295254, "weight":
+        0, "name": "random.fulltest", "target": "challengetoken", "port": 0, "type":
+        "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null, "service":
+        null, "id": 9295255, "weight": 0, "name": "random.test", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}], "page": 1, "pages":
+        1, "results": 14}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2759']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:28 GMT']
+      retry-after: ['113']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['397']
+      x-ratelimit-reset: ['1525257982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "orig.test", "target":
+      "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['78']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295256, "weight": 0, "name": "orig.test", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['180']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:30 GMT']
+      retry-after: ['111']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['396']
+      x-ratelimit-reset: ['1525257982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295251, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.listrecordset", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295252, "target":
+        "challengetoken2", "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295253, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "random.fqdntest", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295254, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "random.fulltest", "ttl_sec": 0,
+        "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295255, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "random.test", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight":
+        0, "type": "TXT"}, {"id": 9295256, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "orig.test", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}], "results": 15}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2941']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:31 GMT']
+      retry-after: ['82']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"type": "TXT", "name": "updated.test", "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['67']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.linode.com/v4/domains/1065421/records/9295256
+  response:
+    body: {string: !!python/unicode '{"name": "updated.test", "id": 9295256, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['183']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:33 GMT']
+      retry-after: ['86']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,288 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:34 GMT']
+      retry-after: ['71']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 15, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "random.test", "id": 9295255, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}, {"name": "updated.test",
+        "id": 9295256, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['2944']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:36 GMT']
+      retry-after: ['83']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257960']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "orig.nameonly.test",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['87']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"name": "orig.nameonly.test", "id": 9295257,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['189']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:37 GMT']
+      retry-after: ['70']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"id": 9295232,
+        "target": "127.0.0.1", "service": null, "protocol": null, "name": "localhost",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "A"}, {"id": 9295233, "target": "docs.example.com", "service": null, "protocol":
+        null, "name": "docs", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0,
+        "weight": 0, "type": "CNAME"}, {"id": 9295234, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.fqdn", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295236, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "_acme-challenge.full", "ttl_sec": 0, "priority": 0, "tag": null, "port":
+        0, "weight": 0, "type": "TXT"}, {"id": 9295237, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "_acme-challenge.test", "ttl_sec":
+        0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295238, "target": "challengetoken1", "service": null, "protocol": null, "name":
+        "_acme-challenge.createrecordset", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295239, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.createrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295240, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "_acme-challenge.noop", "ttl_sec": 0, "priority": 0, "tag":
+        null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295247, "target": "challengetoken2",
+        "service": null, "protocol": null, "name": "_acme-challenge.deleterecordinset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295251, "target": "challengetoken1", "service": null, "protocol":
+        null, "name": "_acme-challenge.listrecordset", "ttl_sec": 0, "priority": 0,
+        "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295252, "target":
+        "challengetoken2", "service": null, "protocol": null, "name": "_acme-challenge.listrecordset",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}, {"id": 9295253, "target": "challengetoken", "service": null, "protocol":
+        null, "name": "random.fqdntest", "ttl_sec": 0, "priority": 0, "tag": null,
+        "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295254, "target": "challengetoken",
+        "service": null, "protocol": null, "name": "random.fulltest", "ttl_sec": 0,
+        "priority": 0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id":
+        9295255, "target": "challengetoken", "service": null, "protocol": null, "name":
+        "random.test", "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight":
+        0, "type": "TXT"}, {"id": 9295256, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "updated.test", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}, {"id": 9295257, "target":
+        "challengetoken", "service": null, "protocol": null, "name": "orig.nameonly.test",
+        "ttl_sec": 0, "priority": 0, "tag": null, "port": 0, "weight": 0, "type":
+        "TXT"}], "results": 16}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['3135']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:39 GMT']
+      retry-after: ['74']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"type": "TXT", "name": "orig.nameonly.test", "target":
+      "updated"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['66']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.linode.com/v4/domains/1065421/records/9295257
+  response:
+    body: {string: !!python/unicode '{"id": 9295257, "target": "updated", "service":
+        null, "protocol": null, "name": "orig.nameonly.test", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['182']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:40 GMT']
+      retry-after: ['73']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['392']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,292 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:42 GMT']
+      retry-after: ['63']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['394']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 16, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "random.test", "id": 9295255, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}, {"name": "updated.test",
+        "id": 9295256, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "orig.nameonly.test", "id": 9295257, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "updated",
+        "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['3128']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:43 GMT']
+      retry-after: ['64']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "orig.testfqdn",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['82']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295258, "weight": 0, "name": "orig.testfqdn", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['184']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:45 GMT']
+      retry-after: ['96']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['395']
+      x-ratelimit-reset: ['1525257982']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"data": [{"priority": 0, "tag": null, "service":
+        null, "id": 9295232, "weight": 0, "name": "localhost", "target": "127.0.0.1",
+        "port": 0, "type": "A", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295233, "weight": 0, "name": "docs", "target":
+        "docs.example.com", "port": 0, "type": "CNAME", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295234, "weight":
+        0, "name": "_acme-challenge.fqdn", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295236, "weight": 0, "name": "_acme-challenge.full",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295237, "weight":
+        0, "name": "_acme-challenge.test", "target": "challengetoken", "port": 0,
+        "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null,
+        "service": null, "id": 9295238, "weight": 0, "name": "_acme-challenge.createrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295239, "weight":
+        0, "name": "_acme-challenge.createrecordset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295240, "weight": 0, "name": "_acme-challenge.noop",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295247, "weight":
+        0, "name": "_acme-challenge.deleterecordinset", "target": "challengetoken2",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295251, "weight": 0, "name": "_acme-challenge.listrecordset",
+        "target": "challengetoken1", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295252, "weight":
+        0, "name": "_acme-challenge.listrecordset", "target": "challengetoken2", "port":
+        0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag":
+        null, "service": null, "id": 9295253, "weight": 0, "name": "random.fqdntest",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295254, "weight":
+        0, "name": "random.fulltest", "target": "challengetoken", "port": 0, "type":
+        "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null, "service":
+        null, "id": 9295255, "weight": 0, "name": "random.test", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}, {"priority": 0,
+        "tag": null, "service": null, "id": 9295256, "weight": 0, "name": "updated.test",
+        "target": "challengetoken", "port": 0, "type": "TXT", "ttl_sec": 0, "protocol":
+        null}, {"priority": 0, "tag": null, "service": null, "id": 9295257, "weight":
+        0, "name": "orig.nameonly.test", "target": "updated", "port": 0, "type": "TXT",
+        "ttl_sec": 0, "protocol": null}, {"priority": 0, "tag": null, "service": null,
+        "id": 9295258, "weight": 0, "name": "orig.testfqdn", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}], "page": 1, "pages":
+        1, "results": 17}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['3314']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:46 GMT']
+      retry-after: ['119']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['399']
+      x-ratelimit-reset: ['1525258006']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"type": "TXT", "name": "updated.testfqdn", "target":
+      "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.linode.com/v4/domains/1065421/records/9295258
+  response:
+    body: {string: !!python/unicode '{"id": 9295258, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "updated.testfqdn", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['187']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:48 GMT']
+      retry-after: ['65']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['391']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/linode4/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,296 @@
+interactions:
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+      X-Filter: ['{"domain": "lexicon-test.com"}']
+    method: GET
+    uri: https://api.linode.com/v4/domains
+  response:
+    body: {string: !!python/unicode '{"pages": 1, "page": 1, "data": [{"soa_email":
+        "contact@lexicon.com", "status": "active", "description": "", "refresh_sec":
+        0, "id": 1065421, "retry_sec": 0, "type": "master", "domain": "lexicon-test.com",
+        "ttl_sec": 0, "master_ips": [], "group": "", "axfr_ips": [], "expire_sec":
+        0}], "results": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['299']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:49 GMT']
+      retry-after: ['56']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['393']
+      x-ratelimit-reset: ['1525257946']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 17, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "random.test", "id": 9295255, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}, {"name": "updated.test",
+        "id": 9295256, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "orig.nameonly.test", "id": 9295257, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "updated",
+        "protocol": null, "tag": null}, {"name": "updated.testfqdn", "id": 9295258,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['3317']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:51 GMT']
+      retry-after: ['56']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['389']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"ttl_sec": 0, "type": "TXT", "name": "orig.testfull",
+      "target": "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['82']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"id": 9295259, "target": "challengetoken", "service":
+        null, "protocol": null, "name": "orig.testfull", "ttl_sec": 0, "priority":
+        0, "tag": null, "port": 0, "weight": 0, "type": "TXT"}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['184']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:52 GMT']
+      retry-after: ['61']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['390']
+      x-ratelimit-reset: ['1525257954']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['2']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://api.linode.com/v4/domains/1065421/records
+  response:
+    body: {string: !!python/unicode '{"results": 18, "pages": 1, "data": [{"name":
+        "localhost", "id": 9295232, "weight": 0, "service": null, "type": "A", "ttl_sec":
+        0, "port": 0, "priority": 0, "target": "127.0.0.1", "protocol": null, "tag":
+        null}, {"name": "docs", "id": 9295233, "weight": 0, "service": null, "type":
+        "CNAME", "ttl_sec": 0, "port": 0, "priority": 0, "target": "docs.example.com",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.fqdn", "id": 9295234,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "_acme-challenge.full",
+        "id": 9295236, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.test", "id": 9295237, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "_acme-challenge.createrecordset",
+        "id": 9295238, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.createrecordset", "id": 9295239, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.noop",
+        "id": 9295240, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.deleterecordinset", "id": 9295247, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "_acme-challenge.listrecordset",
+        "id": 9295251, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken1", "protocol": null, "tag":
+        null}, {"name": "_acme-challenge.listrecordset", "id": 9295252, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken2", "protocol": null, "tag": null}, {"name": "random.fqdntest",
+        "id": 9295253, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "random.fulltest", "id": 9295254, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "challengetoken",
+        "protocol": null, "tag": null}, {"name": "random.test", "id": 9295255, "weight":
+        0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0,
+        "target": "challengetoken", "protocol": null, "tag": null}, {"name": "updated.test",
+        "id": 9295256, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}, {"name": "orig.nameonly.test", "id": 9295257, "weight": 0, "service":
+        null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority": 0, "target": "updated",
+        "protocol": null, "tag": null}, {"name": "updated.testfqdn", "id": 9295258,
+        "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0, "port": 0, "priority":
+        0, "target": "challengetoken", "protocol": null, "tag": null}, {"name": "orig.testfull",
+        "id": 9295259, "weight": 0, "service": null, "type": "TXT", "ttl_sec": 0,
+        "port": 0, "priority": 0, "target": "challengetoken", "protocol": null, "tag":
+        null}], "page": 1}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=0, s-maxage=0, no-cache, no-store', 'private,
+          max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['3503']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:54 GMT']
+      retry-after: ['53']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter', 'Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_only']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['388']
+      x-ratelimit-reset: ['1525257948']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"type": "TXT", "name": "updated.testfull", "target":
+      "challengetoken"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['71']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: PUT
+    uri: https://api.linode.com/v4/domains/1065421/records/9295259
+  response:
+    body: {string: !!python/unicode '{"priority": 0, "tag": null, "service": null,
+        "id": 9295259, "weight": 0, "name": "updated.testfull", "target": "challengetoken",
+        "port": 0, "type": "TXT", "ttl_sec": 0, "protocol": null}'}
+    headers:
+      access-control-allow-credentials: ['true']
+      access-control-allow-headers: ['Authorization, Origin, X-Requested-With, Content-Type,
+          Accept, X-Filter']
+      access-control-allow-methods: ['HEAD, GET, OPTIONS, POST, PUT, DELETE']
+      access-control-allow-origin: ['*']
+      access-control-expose-headers: ['X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status']
+      cache-control: ['private, max-age=60, s-maxage=60']
+      connection: [keep-alive]
+      content-length: ['187']
+      content-security-policy: [default-src 'none']
+      content-type: [application/json]
+      date: ['Wed, 02 May 2018 10:44:55 GMT']
+      retry-after: ['110']
+      server: [nginx]
+      strict-transport-security: [max-age=31536000]
+      vary: ['Authorization, X-Filter']
+      x-accepted-oauth-scopes: ['domains:read_write']
+      x-content-type-options: [nosniff, nosniff]
+      x-frame-options: [DENY, DENY]
+      x-oauth-scopes: ['domains:read_write']
+      x-ratelimit-limit: ['400']
+      x-ratelimit-remaining: ['398']
+      x-ratelimit-reset: ['1525258006']
+      x-xss-protection: [1; mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_linode4.py
+++ b/tests/providers/test_linode4.py
@@ -1,0 +1,26 @@
+# Test for one implementation of the interface
+from lexicon.providers.linode4 import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class Linode4ProviderTests(TestCase, IntegrationTests):
+
+	Provider = Provider
+	provider_name = 'linode4'
+	domain = 'lexicon-test.com'
+	def _filter_post_data_parameters(self):
+		return []
+
+	def _filter_headers(self):
+		return ['Authorization']
+
+	def _filter_query_parameters(self):
+		return []
+
+	@pytest.mark.skip(reason="can not set ttl when creating/updating records")
+	def test_Provider_when_calling_list_records_after_setting_ttl(self):
+		return


### PR DESCRIPTION
This implemented the Linode v4 API in a new provider.
I've created a new provider because the current v3 api will likely be continued for a long time. Additionally, the new API only works with API Key from cloud.linode.com which is still in development.