### PR TITLE
use ttl during creation of new ns1 records

### DIFF
--- a/lexicon/providers/nsone.py
+++ b/lexicon/providers/nsone.py
@@ -66,6 +66,7 @@ class Provider(BaseProvider):
             record = {
                 'type': type,
                 'domain': name,
+                'ttl': self.options.get('ttl'),
                 'zone': self.domain_id,
                 'answers':[
                     {"answer": [content]}


### PR DESCRIPTION
I noticed that my records at NS1 were getting created with the default TTL. This makes the --ttl flag for `lexicon nsone create` if the record is new.

I'm not sure how to handle existing records or updates, but this is enough for my purposes.