### PR TITLE
subreg: Added possibility to modify the name of DNS record.

### DIFF
--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:42 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:42 GMT']
+      date: ['Tue, 15 May 2018 21:07:57 GMT']
+      expires: ['Tue, 15 May 2018 21:07:57 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:42 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:42 GMT']
+      date: ['Tue, 15 May 2018 21:07:57 GMT']
+      expires: ['Tue, 15 May 2018 21:07:57 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:42 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:42 GMT']
+      date: ['Tue, 15 May 2018 21:07:57 GMT']
+      expires: ['Tue, 15 May 2018 21:07:57 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:43 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:43 GMT']
+      date: ['Tue, 15 May 2018 21:07:57 GMT']
+      expires: ['Tue, 15 May 2018 21:07:57 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:43 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:43 GMT']
+      date: ['Tue, 15 May 2018 21:07:58 GMT']
+      expires: ['Tue, 15 May 2018 21:07:58 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:43 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:43 GMT']
+      date: ['Tue, 15 May 2018 21:07:58 GMT']
+      expires: ['Tue, 15 May 2018 21:07:58 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['341']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:44 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:44 GMT']
+      date: ['Tue, 15 May 2018 21:07:58 GMT']
+      expires: ['Tue, 15 May 2018 21:07:58 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>A</type><name>localhost</name><content>127.0.0.1</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>A</type><name>localhost</name><content>127.0.0.1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['547']
+      Content-Length: ['506']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:44 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:44 GMT']
+      date: ['Tue, 15 May 2018 21:07:58 GMT']
+      expires: ['Tue, 15 May 2018 21:07:58 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:44 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:44 GMT']
+      date: ['Tue, 15 May 2018 21:07:59 GMT']
+      expires: ['Tue, 15 May 2018 21:07:59 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:45 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:45 GMT']
+      date: ['Tue, 15 May 2018 21:07:59 GMT']
+      expires: ['Tue, 15 May 2018 21:07:59 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['469']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:39:45 GMT']
-      expires: ['Thu, 26 Apr 2018 21:39:45 GMT']
+      date: ['Tue, 15 May 2018 21:07:59 GMT']
+      expires: ['Tue, 15 May 2018 21:07:59 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>CNAME</type><name>docs</name><content>docs.example.com</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>CNAME</type><name>docs</name><content>docs.example.com</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['553']
+      Content-Length: ['512']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:01 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:01 GMT']
+      date: ['Tue, 15 May 2018 21:08:00 GMT']
+      expires: ['Tue, 15 May 2018 21:08:00 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:02 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:02 GMT']
+      date: ['Tue, 15 May 2018 21:08:00 GMT']
+      expires: ['Tue, 15 May 2018 21:08:00 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:05 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:05 GMT']
+      date: ['Tue, 15 May 2018 21:08:00 GMT']
+      expires: ['Tue, 15 May 2018 21:08:00 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['603']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:05 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:05 GMT']
+      date: ['Tue, 15 May 2018 21:08:01 GMT']
+      expires: ['Tue, 15 May 2018 21:08:01 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.fqdn</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.fqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['565']
+      Content-Length: ['524']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:05 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:05 GMT']
+      date: ['Tue, 15 May 2018 21:08:01 GMT']
+      expires: ['Tue, 15 May 2018 21:08:01 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:06 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:06 GMT']
+      date: ['Tue, 15 May 2018 21:08:01 GMT']
+      expires: ['Tue, 15 May 2018 21:08:01 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:06 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:06 GMT']
+      date: ['Tue, 15 May 2018 21:08:02 GMT']
+      expires: ['Tue, 15 May 2018 21:08:02 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['749']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:06 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:06 GMT']
+      date: ['Tue, 15 May 2018 21:08:02 GMT']
+      expires: ['Tue, 15 May 2018 21:08:02 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.full</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.full</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['565']
+      Content-Length: ['524']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:06 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:06 GMT']
+      date: ['Tue, 15 May 2018 21:08:02 GMT']
+      expires: ['Tue, 15 May 2018 21:08:02 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:07 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:07 GMT']
+      date: ['Tue, 15 May 2018 21:08:03 GMT']
+      expires: ['Tue, 15 May 2018 21:08:03 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:07 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:07 GMT']
+      date: ['Tue, 15 May 2018 21:08:03 GMT']
+      expires: ['Tue, 15 May 2018 21:08:03 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['895']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:07 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:07 GMT']
+      date: ['Tue, 15 May 2018 21:08:03 GMT']
+      expires: ['Tue, 15 May 2018 21:08:03 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.test</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['565']
+      Content-Length: ['524']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:07 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:07 GMT']
+      date: ['Tue, 15 May 2018 21:08:03 GMT']
+      expires: ['Tue, 15 May 2018 21:08:03 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:08 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:08 GMT']
+      date: ['Tue, 15 May 2018 21:08:04 GMT']
+      expires: ['Tue, 15 May 2018 21:08:04 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:08 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:08 GMT']
+      date: ['Tue, 15 May 2018 21:08:04 GMT']
+      expires: ['Tue, 15 May 2018 21:08:04 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1041']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:08 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:08 GMT']
+      date: ['Tue, 15 May 2018 21:08:04 GMT']
+      expires: ['Tue, 15 May 2018 21:08:04 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken1</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['577']
+      Content-Length: ['536']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:08 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:08 GMT']
+      date: ['Tue, 15 May 2018 21:08:05 GMT']
+      expires: ['Tue, 15 May 2018 21:08:05 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1199']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:09 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:09 GMT']
+      date: ['Tue, 15 May 2018 21:08:05 GMT']
+      expires: ['Tue, 15 May 2018 21:08:05 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken2</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['577']
+      Content-Length: ['536']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:09 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:09 GMT']
+      date: ['Tue, 15 May 2018 21:08:05 GMT']
+      expires: ['Tue, 15 May 2018 21:08:05 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:10 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:10 GMT']
+      date: ['Tue, 15 May 2018 21:08:05 GMT']
+      expires: ['Tue, 15 May 2018 21:08:05 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:10 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:10 GMT']
+      date: ['Tue, 15 May 2018 21:08:06 GMT']
+      expires: ['Tue, 15 May 2018 21:08:06 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1357']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:10 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:10 GMT']
+      date: ['Tue, 15 May 2018 21:08:06 GMT']
+      expires: ['Tue, 15 May 2018 21:08:06 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.noop</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.noop</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['565']
+      Content-Length: ['524']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:10 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:10 GMT']
+      date: ['Tue, 15 May 2018 21:08:06 GMT']
+      expires: ['Tue, 15 May 2018 21:08:06 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:11 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:11 GMT']
+      date: ['Tue, 15 May 2018 21:08:06 GMT']
+      expires: ['Tue, 15 May 2018 21:08:06 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -166,7 +166,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:11 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:11 GMT']
+      date: ['Tue, 15 May 2018 21:08:07 GMT']
+      expires: ['Tue, 15 May 2018 21:08:07 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:11 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:11 GMT']
+      date: ['Tue, 15 May 2018 21:08:07 GMT']
+      expires: ['Tue, 15 May 2018 21:08:07 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:11 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:11 GMT']
+      date: ['Tue, 15 May 2018 21:08:07 GMT']
+      expires: ['Tue, 15 May 2018 21:08:07 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:11 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:11 GMT']
+      date: ['Tue, 15 May 2018 21:08:08 GMT']
+      expires: ['Tue, 15 May 2018 21:08:08 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfilt</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfilt</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['560']
+      Content-Length: ['519']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:12 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:12 GMT']
+      date: ['Tue, 15 May 2018 21:08:08 GMT']
+      expires: ['Tue, 15 May 2018 21:08:08 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822622</id><name>delete.testfilt</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854799</id><name>delete.testfilt</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:12 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:12 GMT']
+      date: ['Tue, 15 May 2018 21:08:08 GMT']
+      expires: ['Tue, 15 May 2018 21:08:08 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,7 +153,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822622</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854799</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:12 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:12 GMT']
+      date: ['Tue, 15 May 2018 21:08:08 GMT']
+      expires: ['Tue, 15 May 2018 21:08:08 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:12 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:12 GMT']
+      date: ['Tue, 15 May 2018 21:08:08 GMT']
+      expires: ['Tue, 15 May 2018 21:08:08 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:13 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:13 GMT']
+      date: ['Tue, 15 May 2018 21:08:09 GMT']
+      expires: ['Tue, 15 May 2018 21:08:09 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:13 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:13 GMT']
+      date: ['Tue, 15 May 2018 21:08:09 GMT']
+      expires: ['Tue, 15 May 2018 21:08:09 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:13 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:13 GMT']
+      date: ['Tue, 15 May 2018 21:08:09 GMT']
+      expires: ['Tue, 15 May 2018 21:08:09 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfqdn</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['560']
+      Content-Length: ['519']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:13 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:13 GMT']
+      date: ['Tue, 15 May 2018 21:08:09 GMT']
+      expires: ['Tue, 15 May 2018 21:08:09 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822623</id><name>delete.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854800</id><name>delete.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:14 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:14 GMT']
+      date: ['Tue, 15 May 2018 21:08:10 GMT']
+      expires: ['Tue, 15 May 2018 21:08:10 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,7 +153,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822623</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854800</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:14 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:14 GMT']
+      date: ['Tue, 15 May 2018 21:08:10 GMT']
+      expires: ['Tue, 15 May 2018 21:08:10 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:15 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:15 GMT']
+      date: ['Tue, 15 May 2018 21:08:10 GMT']
+      expires: ['Tue, 15 May 2018 21:08:10 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:15 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:15 GMT']
+      date: ['Tue, 15 May 2018 21:08:10 GMT']
+      expires: ['Tue, 15 May 2018 21:08:10 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:15 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:15 GMT']
+      date: ['Tue, 15 May 2018 21:08:11 GMT']
+      expires: ['Tue, 15 May 2018 21:08:11 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:15 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:15 GMT']
+      date: ['Tue, 15 May 2018 21:08:11 GMT']
+      expires: ['Tue, 15 May 2018 21:08:11 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfull</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfull</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['560']
+      Content-Length: ['519']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:16 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:16 GMT']
+      date: ['Tue, 15 May 2018 21:08:11 GMT']
+      expires: ['Tue, 15 May 2018 21:08:11 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822624</id><name>delete.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854801</id><name>delete.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:16 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:16 GMT']
+      date: ['Tue, 15 May 2018 21:08:12 GMT']
+      expires: ['Tue, 15 May 2018 21:08:12 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,7 +153,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822624</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854801</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:16 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:16 GMT']
+      date: ['Tue, 15 May 2018 21:08:12 GMT']
+      expires: ['Tue, 15 May 2018 21:08:12 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:16 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:16 GMT']
+      date: ['Tue, 15 May 2018 21:08:12 GMT']
+      expires: ['Tue, 15 May 2018 21:08:12 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:17 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:17 GMT']
+      date: ['Tue, 15 May 2018 21:08:13 GMT']
+      expires: ['Tue, 15 May 2018 21:08:13 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:17 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:17 GMT']
+      date: ['Tue, 15 May 2018 21:08:13 GMT']
+      expires: ['Tue, 15 May 2018 21:08:13 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:17 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:17 GMT']
+      date: ['Tue, 15 May 2018 21:08:13 GMT']
+      expires: ['Tue, 15 May 2018 21:08:13 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testid</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testid</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['558']
+      Content-Length: ['517']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:17 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:17 GMT']
+      date: ['Tue, 15 May 2018 21:08:13 GMT']
+      expires: ['Tue, 15 May 2018 21:08:13 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822625</id><name>delete.testid</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854802</id><name>delete.testid</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1642']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:18 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:18 GMT']
+      date: ['Tue, 15 May 2018 21:08:14 GMT']
+      expires: ['Tue, 15 May 2018 21:08:14 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,7 +153,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822625</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854802</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:18 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:18 GMT']
+      date: ['Tue, 15 May 2018 21:08:14 GMT']
+      expires: ['Tue, 15 May 2018 21:08:14 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:18 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:18 GMT']
+      date: ['Tue, 15 May 2018 21:08:14 GMT']
+      expires: ['Tue, 15 May 2018 21:08:14 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:18 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:18 GMT']
+      date: ['Tue, 15 May 2018 21:08:14 GMT']
+      expires: ['Tue, 15 May 2018 21:08:14 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:19 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:19 GMT']
+      date: ['Tue, 15 May 2018 21:08:15 GMT']
+      expires: ['Tue, 15 May 2018 21:08:15 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:19 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:19 GMT']
+      date: ['Tue, 15 May 2018 21:08:15 GMT']
+      expires: ['Tue, 15 May 2018 21:08:15 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken1</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['579']
+      Content-Length: ['538']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:19 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:19 GMT']
+      date: ['Tue, 15 May 2018 21:08:15 GMT']
+      expires: ['Tue, 15 May 2018 21:08:15 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822626</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854803</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:19 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:19 GMT']
+      date: ['Tue, 15 May 2018 21:08:15 GMT']
+      expires: ['Tue, 15 May 2018 21:08:15 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken2</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['579']
+      Content-Length: ['538']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:20 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:20 GMT']
+      date: ['Tue, 15 May 2018 21:08:16 GMT']
+      expires: ['Tue, 15 May 2018 21:08:16 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822626</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854803</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1823']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:20 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:20 GMT']
+      date: ['Tue, 15 May 2018 21:08:16 GMT']
+      expires: ['Tue, 15 May 2018 21:08:16 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -213,7 +213,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822626</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854803</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -234,8 +234,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:20 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:20 GMT']
+      date: ['Tue, 15 May 2018 21:08:16 GMT']
+      expires: ['Tue, 15 May 2018 21:08:16 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -256,7 +256,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -264,8 +264,8 @@ interactions:
       connection: [close]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:20 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:20 GMT']
+      date: ['Tue, 15 May 2018 21:08:16 GMT']
+      expires: ['Tue, 15 May 2018 21:08:16 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:21 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:21 GMT']
+      date: ['Tue, 15 May 2018 21:08:17 GMT']
+      expires: ['Tue, 15 May 2018 21:08:17 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:21 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:21 GMT']
+      date: ['Tue, 15 May 2018 21:08:17 GMT']
+      expires: ['Tue, 15 May 2018 21:08:17 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:21 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:21 GMT']
+      date: ['Tue, 15 May 2018 21:08:17 GMT']
+      expires: ['Tue, 15 May 2018 21:08:17 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken1</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['577']
+      Content-Length: ['536']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:21 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:21 GMT']
+      date: ['Tue, 15 May 2018 21:08:18 GMT']
+      expires: ['Tue, 15 May 2018 21:08:18 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822628</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854805</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1821']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:22 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:22 GMT']
+      date: ['Tue, 15 May 2018 21:08:18 GMT']
+      expires: ['Tue, 15 May 2018 21:08:18 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken2</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['577']
+      Content-Length: ['536']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:22 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:22 GMT']
+      date: ['Tue, 15 May 2018 21:08:18 GMT']
+      expires: ['Tue, 15 May 2018 21:08:18 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822628</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822629</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854805</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854806</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['1979']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:22 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:22 GMT']
+      date: ['Tue, 15 May 2018 21:08:18 GMT']
+      expires: ['Tue, 15 May 2018 21:08:18 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -213,7 +213,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822628</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854805</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -234,8 +234,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:22 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:22 GMT']
+      date: ['Tue, 15 May 2018 21:08:19 GMT']
+      expires: ['Tue, 15 May 2018 21:08:19 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -243,7 +243,7 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822629</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854806</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
       Content-Length: ['449']
@@ -264,8 +264,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:23 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:23 GMT']
+      date: ['Tue, 15 May 2018 21:08:19 GMT']
+      expires: ['Tue, 15 May 2018 21:08:19 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -286,7 +286,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -294,8 +294,8 @@ interactions:
       connection: [close]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:23 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:23 GMT']
+      date: ['Tue, 15 May 2018 21:08:19 GMT']
+      expires: ['Tue, 15 May 2018 21:08:19 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:23 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:23 GMT']
+      date: ['Tue, 15 May 2018 21:08:19 GMT']
+      expires: ['Tue, 15 May 2018 21:08:19 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:23 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:23 GMT']
+      date: ['Tue, 15 May 2018 21:08:20 GMT']
+      expires: ['Tue, 15 May 2018 21:08:20 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:24 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:24 GMT']
+      date: ['Tue, 15 May 2018 21:08:20 GMT']
+      expires: ['Tue, 15 May 2018 21:08:20 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>ttl.fqdn</name><content>ttlshouldbe3600</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>ttl.fqdn</name><content>ttlshouldbe3600</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['554']
+      Content-Length: ['513']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:24 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:24 GMT']
+      date: ['Tue, 15 May 2018 21:08:20 GMT']
+      expires: ['Tue, 15 May 2018 21:08:20 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1798']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:24 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:24 GMT']
+      date: ['Tue, 15 May 2018 21:08:20 GMT']
+      expires: ['Tue, 15 May 2018 21:08:20 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:24 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:24 GMT']
+      date: ['Tue, 15 May 2018 21:08:21 GMT']
+      expires: ['Tue, 15 May 2018 21:08:21 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:25 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:25 GMT']
+      date: ['Tue, 15 May 2018 21:08:21 GMT']
+      expires: ['Tue, 15 May 2018 21:08:21 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['1798']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:25 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:25 GMT']
+      date: ['Tue, 15 May 2018 21:08:21 GMT']
+      expires: ['Tue, 15 May 2018 21:08:21 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken1</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['575']
+      Content-Length: ['534']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:25 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:25 GMT']
+      date: ['Tue, 15 May 2018 21:08:21 GMT']
+      expires: ['Tue, 15 May 2018 21:08:21 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['1954']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:25 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:25 GMT']
+      date: ['Tue, 15 May 2018 21:08:22 GMT']
+      expires: ['Tue, 15 May 2018 21:08:22 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken2</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['575']
+      Content-Length: ['534']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:26 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:26 GMT']
+      date: ['Tue, 15 May 2018 21:08:22 GMT']
+      expires: ['Tue, 15 May 2018 21:08:22 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -196,7 +196,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -204,8 +204,8 @@ interactions:
       connection: [close]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:26 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:26 GMT']
+      date: ['Tue, 15 May 2018 21:08:22 GMT']
+      expires: ['Tue, 15 May 2018 21:08:22 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:26 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:26 GMT']
+      date: ['Tue, 15 May 2018 21:08:22 GMT']
+      expires: ['Tue, 15 May 2018 21:08:22 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:26 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:26 GMT']
+      date: ['Tue, 15 May 2018 21:08:23 GMT']
+      expires: ['Tue, 15 May 2018 21:08:23 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:27 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:27 GMT']
+      date: ['Tue, 15 May 2018 21:08:23 GMT']
+      expires: ['Tue, 15 May 2018 21:08:23 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_arguments_should_filter_list.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_arguments_should_filter_list.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:27 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:27 GMT']
+      date: ['Tue, 15 May 2018 21:08:23 GMT']
+      expires: ['Tue, 15 May 2018 21:08:23 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:27 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:27 GMT']
+      date: ['Tue, 15 May 2018 21:08:23 GMT']
+      expires: ['Tue, 15 May 2018 21:08:23 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:27 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:27 GMT']
+      date: ['Tue, 15 May 2018 21:08:24 GMT']
+      expires: ['Tue, 15 May 2018 21:08:24 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:27 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:27 GMT']
+      date: ['Tue, 15 May 2018 21:08:24 GMT']
+      expires: ['Tue, 15 May 2018 21:08:24 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:28 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:28 GMT']
+      date: ['Tue, 15 May 2018 21:08:24 GMT']
+      expires: ['Tue, 15 May 2018 21:08:24 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:28 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:28 GMT']
+      date: ['Tue, 15 May 2018 21:08:24 GMT']
+      expires: ['Tue, 15 May 2018 21:08:24 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fqdntest</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fqdntest</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['560']
+      Content-Length: ['519']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:28 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:28 GMT']
+      date: ['Tue, 15 May 2018 21:08:25 GMT']
+      expires: ['Tue, 15 May 2018 21:08:25 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['2251']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:28 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:28 GMT']
+      date: ['Tue, 15 May 2018 21:08:25 GMT']
+      expires: ['Tue, 15 May 2018 21:08:25 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:29 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:29 GMT']
+      date: ['Tue, 15 May 2018 21:08:25 GMT']
+      expires: ['Tue, 15 May 2018 21:08:25 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:29 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:29 GMT']
+      date: ['Tue, 15 May 2018 21:08:26 GMT']
+      expires: ['Tue, 15 May 2018 21:08:26 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2251']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:29 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:29 GMT']
+      date: ['Tue, 15 May 2018 21:08:26 GMT']
+      expires: ['Tue, 15 May 2018 21:08:26 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fulltest</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fulltest</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['560']
+      Content-Length: ['519']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:29 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:29 GMT']
+      date: ['Tue, 15 May 2018 21:08:26 GMT']
+      expires: ['Tue, 15 May 2018 21:08:26 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:29 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:29 GMT']
+      date: ['Tue, 15 May 2018 21:08:26 GMT']
+      expires: ['Tue, 15 May 2018 21:08:26 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:30 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:30 GMT']
+      date: ['Tue, 15 May 2018 21:08:27 GMT']
+      expires: ['Tue, 15 May 2018 21:08:27 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:30 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:30 GMT']
+      date: ['Tue, 15 May 2018 21:08:27 GMT']
+      expires: ['Tue, 15 May 2018 21:08:27 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:30 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:30 GMT']
+      date: ['Tue, 15 May 2018 21:08:27 GMT']
+      expires: ['Tue, 15 May 2018 21:08:27 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:30 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:30 GMT']
+      date: ['Tue, 15 May 2018 21:08:27 GMT']
+      expires: ['Tue, 15 May 2018 21:08:27 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:30 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:30 GMT']
+      date: ['Tue, 15 May 2018 21:08:28 GMT']
+      expires: ['Tue, 15 May 2018 21:08:28 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:31 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:31 GMT']
+      date: ['Tue, 15 May 2018 21:08:28 GMT']
+      expires: ['Tue, 15 May 2018 21:08:28 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.test</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['556']
+      Content-Length: ['515']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:31 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:31 GMT']
+      date: ['Tue, 15 May 2018 21:08:28 GMT']
+      expires: ['Tue, 15 May 2018 21:08:28 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:31 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:31 GMT']
+      date: ['Tue, 15 May 2018 21:08:28 GMT']
+      expires: ['Tue, 15 May 2018 21:08:28 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:32 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:32 GMT']
+      date: ['Tue, 15 May 2018 21:08:29 GMT']
+      expires: ['Tue, 15 May 2018 21:08:29 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:32 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:32 GMT']
+      date: ['Tue, 15 May 2018 21:08:29 GMT']
+      expires: ['Tue, 15 May 2018 21:08:29 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:32 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:32 GMT']
+      date: ['Tue, 15 May 2018 21:08:29 GMT']
+      expires: ['Tue, 15 May 2018 21:08:29 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:32 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:32 GMT']
+      date: ['Tue, 15 May 2018 21:08:30 GMT']
+      expires: ['Tue, 15 May 2018 21:08:30 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:32 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:32 GMT']
+      date: ['Tue, 15 May 2018 21:08:30 GMT']
+      expires: ['Tue, 15 May 2018 21:08:30 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,7 +76,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -84,8 +84,8 @@ interactions:
       connection: [close]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:33 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:33 GMT']
+      date: ['Tue, 15 May 2018 21:08:30 GMT']
+      expires: ['Tue, 15 May 2018 21:08:30 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.test</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['554']
+      Content-Length: ['513']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:33 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:33 GMT']
+      date: ['Tue, 15 May 2018 21:08:30 GMT']
+      expires: ['Tue, 15 May 2018 21:08:30 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,7 +136,7 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854813</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -144,8 +144,8 @@ interactions:
       connection: [close]
       content-length: ['2664']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:33 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:33 GMT']
+      date: ['Tue, 15 May 2018 21:08:31 GMT']
+      expires: ['Tue, 15 May 2018 21:08:31 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822636</id><type>TXT</type><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['554']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -166,7 +166,67 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Modify_DNS_Record_Container><response><status>ok</status></response></ns1:Modify_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854813</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['2664']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:31 GMT']
+      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.test</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['530']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Add_DNS_Record_Container><response><status>ok</status><data/></response></ns1:Add_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['312']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:31 GMT']
+      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854813</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['449']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Delete_DNS_Record_Container><response><status>ok</status></response></ns1:Delete_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -174,8 +234,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:33 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:33 GMT']
+      date: ['Tue, 15 May 2018 21:08:31 GMT']
+      expires: ['Tue, 15 May 2018 21:08:31 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:34 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:34 GMT']
+      date: ['Tue, 15 May 2018 21:08:32 GMT']
+      expires: ['Tue, 15 May 2018 21:08:32 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:34 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:34 GMT']
+      date: ['Tue, 15 May 2018 21:08:32 GMT']
+      expires: ['Tue, 15 May 2018 21:08:32 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,16 +76,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['2664']
+      content-length: ['2667']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:34 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:34 GMT']
+      date: ['Tue, 15 May 2018 21:08:32 GMT']
+      expires: ['Tue, 15 May 2018 21:08:32 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.nameonly.test</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.nameonly.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['563']
+      Content-Length: ['522']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:34 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:34 GMT']
+      date: ['Tue, 15 May 2018 21:08:32 GMT']
+      expires: ['Tue, 15 May 2018 21:08:32 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,16 +136,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822637</id><name>orig.nameonly.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['2808']
+      content-length: ['2811']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:35 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:35 GMT']
+      date: ['Tue, 15 May 2018 21:08:32 GMT']
+      expires: ['Tue, 15 May 2018 21:08:32 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822637</id><type>TXT</type><content>updated</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854815</id><type>TXT</type><content>updated</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['547']
+      Content-Length: ['506']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -174,8 +174,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:35 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:35 GMT']
+      date: ['Tue, 15 May 2018 21:08:33 GMT']
+      expires: ['Tue, 15 May 2018 21:08:33 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:35 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:35 GMT']
+      date: ['Tue, 15 May 2018 21:08:33 GMT']
+      expires: ['Tue, 15 May 2018 21:08:33 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:35 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:35 GMT']
+      date: ['Tue, 15 May 2018 21:08:33 GMT']
+      expires: ['Tue, 15 May 2018 21:08:33 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,16 +76,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822637</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['2801']
+      content-length: ['2804']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:36 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:36 GMT']
+      date: ['Tue, 15 May 2018 21:08:33 GMT']
+      expires: ['Tue, 15 May 2018 21:08:33 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfqdn</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['558']
+      Content-Length: ['517']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:36 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:36 GMT']
+      date: ['Tue, 15 May 2018 21:08:34 GMT']
+      expires: ['Tue, 15 May 2018 21:08:34 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,16 +136,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822637</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822638</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854816</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['2940']
+      content-length: ['2943']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:36 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:36 GMT']
+      date: ['Tue, 15 May 2018 21:08:34 GMT']
+      expires: ['Tue, 15 May 2018 21:08:34 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822638</id><type>TXT</type><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['554']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -166,7 +166,67 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Modify_DNS_Record_Container><response><status>ok</status></response></ns1:Modify_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854816</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['2943']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:34 GMT']
+      expires: ['Tue, 15 May 2018 21:08:34 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.testfqdn</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['534']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Add_DNS_Record_Container><response><status>ok</status><data/></response></ns1:Add_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['312']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:35 GMT']
+      expires: ['Tue, 15 May 2018 21:08:35 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854816</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['449']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Delete_DNS_Record_Container><response><status>ok</status></response></ns1:Delete_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -174,8 +234,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:36 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:36 GMT']
+      date: ['Tue, 15 May 2018 21:08:35 GMT']
+      expires: ['Tue, 15 May 2018 21:08:35 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -6,7 +6,7 @@ interactions:
       \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['377']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -24,8 +24,8 @@ interactions:
       connection: [close]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:37 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:37 GMT']
+      date: ['Tue, 15 May 2018 21:08:35 GMT']
+      expires: ['Tue, 15 May 2018 21:08:35 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -54,8 +54,8 @@ interactions:
       connection: [close]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:37 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:37 GMT']
+      date: ['Tue, 15 May 2018 21:08:35 GMT']
+      expires: ['Tue, 15 May 2018 21:08:35 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -76,16 +76,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822637</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822638</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['2940']
+      content-length: ['2946']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:37 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:37 GMT']
+      date: ['Tue, 15 May 2018 21:08:36 GMT']
+      expires: ['Tue, 15 May 2018 21:08:36 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -93,10 +93,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfull</name><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfull</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['558']
+      Content-Length: ['517']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -114,8 +114,8 @@ interactions:
       connection: [close]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:37 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:37 GMT']
+      date: ['Tue, 15 May 2018 21:08:36 GMT']
+      expires: ['Tue, 15 May 2018 21:08:36 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -136,16 +136,16 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3822615</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822614</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822637</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822636</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822638</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822639</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822633</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822634</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822635</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822630</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822619</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822620</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822627</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822616</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822617</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822631</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822632</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822621</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3822618</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854818</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
       connection: [close]
-      content-length: ['3079']
+      content-length: ['3085']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:38 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:38 GMT']
+      date: ['Tue, 15 May 2018 21:08:37 GMT']
+      expires: ['Tue, 15 May 2018 21:08:37 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
@@ -153,10 +153,10 @@ interactions:
     body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
       xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3822639</id><type>TXT</type><content>challengetoken</content><ttl>3600</ttl><priority>placeholder_priority</priority></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
     headers:
       Connection: [close]
-      Content-Length: ['554']
+      Content-Length: ['406']
       Content-Type: [text/xml; charset="UTF-8"]
       Host: [subreg.cz]
       User-Agent: [Python-urllib/2.7]
@@ -166,7 +166,67 @@ interactions:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Modify_DNS_Record_Container><response><status>ok</status></response></ns1:Modify_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854818</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['3085']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:37 GMT']
+      expires: ['Tue, 15 May 2018 21:08:37 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.testfull</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['534']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Add_DNS_Record_Container><response><status>ok</status><data/></response></ns1:Add_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+
+'}
+    headers:
+      cache-control: [max-age=0]
+      connection: [close]
+      content-length: ['312']
+      content-type: [text/xml; charset=utf-8]
+      date: ['Tue, 15 May 2018 21:08:38 GMT']
+      expires: ['Tue, 15 May 2018 21:08:38 GMT']
+      server: [Apache]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
+      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
+      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
+      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854818</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    headers:
+      Connection: [close]
+      Content-Length: ['449']
+      Content-Type: [text/xml; charset="UTF-8"]
+      Host: [subreg.cz]
+      User-Agent: [Python-urllib/2.7]
+    method: POST
+    uri: https://subreg.cz/soap/cmd.php?soap_format=1
+  response:
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
+
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Delete_DNS_Record_Container><response><status>ok</status></response></ns1:Delete_DNS_Record_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
@@ -174,8 +234,8 @@ interactions:
       connection: [close]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Thu, 26 Apr 2018 21:40:38 GMT']
-      expires: ['Thu, 26 Apr 2018 21:40:38 GMT']
+      date: ['Tue, 15 May 2018 21:08:38 GMT']
+      expires: ['Tue, 15 May 2018 21:08:38 GMT']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}


### PR DESCRIPTION
Subreg API does not allow changing the name in the update request,
so first add a new record with the new name and then delete the old
record. As a consequence, the identifier of the record updated in
this way will inevitably change.

Refactored code for better method reusing.