### PR TITLE
Enable offline tests by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ You can test a specific provider using:
 
 	$ py.test tests/providers/test_foo.py
 
+__NB: Please note that by default, tests are replayed from recordings located in `tests/fixtures/cassettes`, not againt the real DNS provider APIs.__
 
 ## Adding a new DNS provider
 
@@ -141,10 +142,12 @@ See [powerdns test suite](https://github.com/AnalogJ/lexicon/blob/82fa5056df2122
 
 ## Test recordings
 
-Now run the `py.test` suite again. It will automatically generate recordings for
-your provider:
+Now you need to run the `py.test` suite again, but in a different mode: the live tests mode. 
+In default test mode, tests are replayed from existing recordings. In live mode, tests are executed against the real DNS provider API, and recordings will automatically be generated for your provider.
 
-	py.test tests/providers/test_foo.py
+To execute the `py.test` suite using the live tests mode, execute py.test with the environment variable `LEXICON_LIVE_TESTS` set to `true` like below:
+
+	LEXICON_LIVE_TESTS=true py.test tests/providers/test_foo.py
 
 If any of the integration tests fail on your provider, you'll need to delete the recordings that were created,
 make your changes and then try again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You can test a specific provider using:
 
 	$ py.test tests/providers/test_foo.py
 
-__NB: Please note that by default, tests are replayed from recordings located in `tests/fixtures/cassettes`, not againt the real DNS provider APIs.__
+_NB: Please note that by default, tests are replayed from recordings located in `tests/fixtures/cassettes`, not againt the real DNS provider APIs._
 
 ## Adding a new DNS provider
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You can test a specific provider using:
 
 	$ py.test tests/providers/test_foo.py
 
-_NB: Please note that by default, tests are replayed from recordings located in `tests/fixtures/cassettes`, not againt the real DNS provider APIs._
+_NB: Please note that by default, tests are replayed from recordings located in `tests/fixtures/cassettes`, not against the real DNS provider APIs._
 
 ## Adding a new DNS provider
 

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -6,7 +6,14 @@ import logging
 from .base import Provider as BaseProvider
 
 try:
-    from transip.service.dns import DnsEntry
+    from transip.service.objects import DnsEntry
+except ImportError:
+    try: 
+        from transip.service.dns import DnsEntry
+    except ImportError:
+        pass
+
+try:
     from transip.service.domain import DomainService
 except ImportError:
     pass

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -9,9 +9,10 @@ import vcr
 import os
 
 # Configure VCR
+record_mode = 'new_episodes' if os.environ.get('LEXICON_LIVE_TESTS', 'false') == 'true' else 'none'
 provider_vcr = vcr.VCR(
         cassette_library_dir='tests/fixtures/cassettes',
-        record_mode='new_episodes',
+        record_mode=record_mode,
         decode_compressed_response=True
 )
 
@@ -362,7 +363,8 @@ class IntegrationTests(object):
     #https://jeffknupp.com/blog/2016/03/07/python-with-context-managers/
     @contextlib.contextmanager
     def _test_fixture_recording(self, test_name, recording_extension='yaml', recording_folder='IntegrationTests'):
-        with provider_vcr.use_cassette(self._cassette_path('{0}/{1}.{2}'.format(recording_folder, test_name, recording_extension)),
+        cassette_path = '{0}/{1}.{2}'.format(recording_folder, test_name, recording_extension)
+        with provider_vcr.use_cassette(self._cassette_path(cassette_path),
                                        filter_headers=self._filter_headers(),
                                        filter_query_parameters=self._filter_query_parameters(),
                                        filter_post_data_parameters=self._filter_post_data_parameters()):


### PR DESCRIPTION
This is an implementation of the test offline mode discussed in issue #209.

By default, pyVCR is configured with `record_mode='none'`, meaning that no real request will be sent. Tests are executed against cassettes records files, and will fail if a cassette does not match the test or is missing. This mode will be used implicitly during CI, avoiding weird consequences to allow a CI system to call the DNS provider API anytime.

For developpers, the environment variable `LEXICON_LIVE_TESTS` can be set to `true`. In this case, pyVCR starts with record_mode='new_episodes', meaning that non-compatible cassettes or missing cassettes will trigger the test execution against the DNS provider API, and resulting cassette will be generated.

Documentation is provided in `CONTRIBUTION.md`.