### PR TITLE
Handle namespace variations of DnsEntry in transip provider

### DIFF
--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -6,7 +6,14 @@ import logging
 from .base import Provider as BaseProvider
 
 try:
-    from transip.service.dns import DnsEntry
+    from transip.service.objects import DnsEntry
+except ImportError:
+    try: 
+        from transip.service.dns import DnsEntry
+    except ImportError:
+        pass
+
+try:
     from transip.service.domain import DomainService
 except ImportError:
     pass


### PR DESCRIPTION
Latest version of Transip python libraries seems to have changed the namespace of the DnsEntry class, required by the provider, from transip.service.dns to transip.service.objects.

This PR ensures with various try/import/except to get the classes from relevant namespaces at runtime, allowing to run lexicon with the old, the new, or none of the transip python library.

This resolves also failing tests on Transip in currently opened PRs when merged.