### PR TITLE
Subreg.cz: Use Zeep instead of PySimpleSOAP library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'namecheap': ['PyNamecheap'],
         'route53': ['boto3'],
         'softlayer': ['SoftLayer'],
-        'subreg': ['pysimplesoap'],
+        'subreg': ['zeep'],
         'transip': ['transip>=0.3.0'],
     },
 

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,61 +1,1373 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:08 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:08 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>9cbf5a2c06906c5575b82a1ab32d8bff</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:57 GMT']
-      expires: ['Tue, 15 May 2018 21:07:57 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:09 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:09 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>9cbf5a2c06906c5575b82a1ab32d8bff</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:57 GMT']
-      expires: ['Tue, 15 May 2018 21:07:57 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,61 +1,1373 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>f43e4ac5f83c4e115d5288e643e48f50</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:57 GMT']
-      expires: ['Tue, 15 May 2018 21:07:57 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:10 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>f43e4ac5f83c4e115d5288e643e48f50</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:57 GMT']
-      expires: ['Tue, 15 May 2018 21:07:57 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>c7a66365ebbf349ef8ff64156996884d</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:58 GMT']
-      expires: ['Tue, 15 May 2018 21:07:58 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:11 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>c7a66365ebbf349ef8ff64156996884d</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:58 GMT']
-      expires: ['Tue, 15 May 2018 21:07:58 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>c7a66365ebbf349ef8ff64156996884d</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['341']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:58 GMT']
-      expires: ['Tue, 15 May 2018 21:07:58 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>A</type><name>localhost</name><content>127.0.0.1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>c7a66365ebbf349ef8ff64156996884d</ssid><domain>oldium.xyz</domain><record><name>localhost</name><type>A</type><content>127.0.0.1</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['506']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['412']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,11 +1428,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:58 GMT']
-      expires: ['Tue, 15 May 2018 21:07:58 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:12 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>885974bac9fcf0487204da0902de6917</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:59 GMT']
-      expires: ['Tue, 15 May 2018 21:07:59 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>885974bac9fcf0487204da0902de6917</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:59 GMT']
-      expires: ['Tue, 15 May 2018 21:07:59 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>885974bac9fcf0487204da0902de6917</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['469']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:07:59 GMT']
-      expires: ['Tue, 15 May 2018 21:07:59 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:33 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>CNAME</type><name>docs</name><content>docs.example.com</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>885974bac9fcf0487204da0902de6917</ssid><domain>oldium.xyz</domain><record><name>docs</name><type>CNAME</type><content>docs.example.com</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['512']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['418']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,11 +1428,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:00 GMT']
-      expires: ['Tue, 15 May 2018 21:08:00 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:34 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:34 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:34 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:34 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>ca54f9ad691fa61ef6761f007f4e96c4</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:00 GMT']
-      expires: ['Tue, 15 May 2018 21:08:00 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>ca54f9ad691fa61ef6761f007f4e96c4</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:00 GMT']
-      expires: ['Tue, 15 May 2018 21:08:00 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>ca54f9ad691fa61ef6761f007f4e96c4</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['603']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:01 GMT']
-      expires: ['Tue, 15 May 2018 21:08:01 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.fqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>ca54f9ad691fa61ef6761f007f4e96c4</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['524']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['430']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,11 +1428,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:01 GMT']
-      expires: ['Tue, 15 May 2018 21:08:01 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:35 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:36 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:36 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>95387e024b77c05860df0edcfc870752</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:01 GMT']
-      expires: ['Tue, 15 May 2018 21:08:01 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:36 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:36 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>95387e024b77c05860df0edcfc870752</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:02 GMT']
-      expires: ['Tue, 15 May 2018 21:08:02 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>95387e024b77c05860df0edcfc870752</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['749']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:02 GMT']
-      expires: ['Tue, 15 May 2018 21:08:02 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.full</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>95387e024b77c05860df0edcfc870752</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['524']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['430']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,11 +1428,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:02 GMT']
-      expires: ['Tue, 15 May 2018 21:08:02 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:37 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>91fdc37c936bdf26b70fcdca92d84c89</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:03 GMT']
-      expires: ['Tue, 15 May 2018 21:08:03 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>91fdc37c936bdf26b70fcdca92d84c89</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:03 GMT']
-      expires: ['Tue, 15 May 2018 21:08:03 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>91fdc37c936bdf26b70fcdca92d84c89</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['895']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:03 GMT']
-      expires: ['Tue, 15 May 2018 21:08:03 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:38 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>91fdc37c936bdf26b70fcdca92d84c89</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['524']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['430']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,11 +1428,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:03 GMT']
-      expires: ['Tue, 15 May 2018 21:08:03 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:39 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:39 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:39 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:39 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:04 GMT']
-      expires: ['Tue, 15 May 2018 21:08:04 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:04 GMT']
-      expires: ['Tue, 15 May 2018 21:08:04 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1041']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:04 GMT']
-      expires: ['Tue, 15 May 2018 21:08:04 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['536']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['442']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:05 GMT']
-      expires: ['Tue, 15 May 2018 21:08:05 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:40 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1199']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:05 GMT']
-      expires: ['Tue, 15 May 2018 21:08:05 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:41 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:41 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.createrecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>0edac3908e5926ffaa70ffb9e9ffa994</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['536']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['442']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,11 +1494,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:05 GMT']
-      expires: ['Tue, 15 May 2018 21:08:05 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:41 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:41 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:42 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:42 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:05 GMT']
-      expires: ['Tue, 15 May 2018 21:08:05 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:42 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:42 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:06 GMT']
-      expires: ['Tue, 15 May 2018 21:08:06 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1357']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:06 GMT']
-      expires: ['Tue, 15 May 2018 21:08:06 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.noop</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['524']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['430']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,71 +1428,78 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:06 GMT']
-      expires: ['Tue, 15 May 2018 21:08:06 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:06 GMT']
-      expires: ['Tue, 15 May 2018 21:08:06 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:43 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>2febd3e84f6e5b5fa162b17e4a7bd8d4</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:07 GMT']
-      expires: ['Tue, 15 May 2018 21:08:07 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:44 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:44 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:45 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:45 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>161af938488019d4bc039009348555b7</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:07 GMT']
-      expires: ['Tue, 15 May 2018 21:08:07 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:07 GMT']
-      expires: ['Tue, 15 May 2018 21:08:07 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:08 GMT']
-      expires: ['Tue, 15 May 2018 21:08:08 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfilt</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid><domain>oldium.xyz</domain><record><name>delete.testfilt</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['519']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['425']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:08 GMT']
-      expires: ['Tue, 15 May 2018 21:08:08 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:46 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854799</id><name>delete.testfilt</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964710</id><name>delete.testfilt</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:08 GMT']
-      expires: ['Tue, 15 May 2018 21:08:08 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854799</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid><domain>oldium.xyz</domain><record><id>3964710</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,41 +1494,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:08 GMT']
-      expires: ['Tue, 15 May 2018 21:08:08 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>161af938488019d4bc039009348555b7</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:08 GMT']
-      expires: ['Tue, 15 May 2018 21:08:08 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:47 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:09 GMT']
-      expires: ['Tue, 15 May 2018 21:08:09 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:09 GMT']
-      expires: ['Tue, 15 May 2018 21:08:09 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:09 GMT']
-      expires: ['Tue, 15 May 2018 21:08:09 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:48 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid><domain>oldium.xyz</domain><record><name>delete.testfqdn</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['519']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['425']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:09 GMT']
-      expires: ['Tue, 15 May 2018 21:08:09 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:49 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:49 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854800</id><name>delete.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964711</id><name>delete.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:10 GMT']
-      expires: ['Tue, 15 May 2018 21:08:10 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:49 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:49 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854800</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid><domain>oldium.xyz</domain><record><id>3964711</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,41 +1494,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:10 GMT']
-      expires: ['Tue, 15 May 2018 21:08:10 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:50 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:50 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a537705fc08f23472405c6ac29ad5e6</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:10 GMT']
-      expires: ['Tue, 15 May 2018 21:08:10 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:50 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:50 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:10 GMT']
-      expires: ['Tue, 15 May 2018 21:08:10 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:11 GMT']
-      expires: ['Tue, 15 May 2018 21:08:11 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:11 GMT']
-      expires: ['Tue, 15 May 2018 21:08:11 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:51 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testfull</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid><domain>oldium.xyz</domain><record><name>delete.testfull</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['519']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['425']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:11 GMT']
-      expires: ['Tue, 15 May 2018 21:08:11 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854801</id><name>delete.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964712</id><name>delete.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1644']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:12 GMT']
-      expires: ['Tue, 15 May 2018 21:08:12 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854801</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid><domain>oldium.xyz</domain><record><id>3964712</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,41 +1494,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:12 GMT']
-      expires: ['Tue, 15 May 2018 21:08:12 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:52 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>3bc23cd7721b6d87d7cf185fa9f98e2e</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:12 GMT']
-      expires: ['Tue, 15 May 2018 21:08:12 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:13 GMT']
-      expires: ['Tue, 15 May 2018 21:08:13 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:53 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:13 GMT']
-      expires: ['Tue, 15 May 2018 21:08:13 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:13 GMT']
-      expires: ['Tue, 15 May 2018 21:08:13 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>delete.testid</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid><domain>oldium.xyz</domain><record><name>delete.testid</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['517']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['423']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:13 GMT']
-      expires: ['Tue, 15 May 2018 21:08:13 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854802</id><name>delete.testid</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964713</id><name>delete.testid</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1642']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:14 GMT']
-      expires: ['Tue, 15 May 2018 21:08:14 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:54 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854802</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid><domain>oldium.xyz</domain><record><id>3964713</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,41 +1494,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:14 GMT']
-      expires: ['Tue, 15 May 2018 21:08:14 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>7723dd6e76b070e6fd9e6da2c9e636b8</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:14 GMT']
-      expires: ['Tue, 15 May 2018 21:08:14 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:55 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>515c26ecded1a72baf98d2766309c500</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:14 GMT']
-      expires: ['Tue, 15 May 2018 21:08:14 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:15 GMT']
-      expires: ['Tue, 15 May 2018 21:08:15 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1503']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:15 GMT']
-      expires: ['Tue, 15 May 2018 21:08:15 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['538']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['444']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:15 GMT']
-      expires: ['Tue, 15 May 2018 21:08:15 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:56 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854803</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964714</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:15 GMT']
-      expires: ['Tue, 15 May 2018 21:08:15 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:57 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:57 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordinset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['538']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['444']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,55 +1494,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:16 GMT']
-      expires: ['Tue, 15 May 2018 21:08:16 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:57 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:57 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854803</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964714</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1823']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:16 GMT']
-      expires: ['Tue, 15 May 2018 21:08:16 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854803</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain><record><id>3964714</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -231,41 +1560,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:16 GMT']
-      expires: ['Tue, 15 May 2018 21:08:16 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      keep-alive: ['timeout=15, max=92']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>515c26ecded1a72baf98d2766309c500</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:16 GMT']
-      expires: ['Tue, 15 May 2018 21:08:16 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      keep-alive: ['timeout=15, max=91']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:58 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:17 GMT']
-      expires: ['Tue, 15 May 2018 21:08:17 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:17 GMT']
-      expires: ['Tue, 15 May 2018 21:08:17 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:17 GMT']
-      expires: ['Tue, 15 May 2018 21:08:17 GMT']
+      date: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      expires: ['Thu, 12 Jul 2018 07:46:59 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['536']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['442']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:18 GMT']
-      expires: ['Tue, 15 May 2018 21:08:18 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854805</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964716</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1821']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:18 GMT']
-      expires: ['Tue, 15 May 2018 21:08:18 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.deleterecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken2</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['536']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['442']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,55 +1494,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:18 GMT']
-      expires: ['Tue, 15 May 2018 21:08:18 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:00 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854805</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854806</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964716</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964717</id><name>_acme-challenge.deleterecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1979']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:18 GMT']
-      expires: ['Tue, 15 May 2018 21:08:18 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854805</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain><record><id>3964716</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -231,25 +1560,28 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:19 GMT']
-      expires: ['Tue, 15 May 2018 21:08:19 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      keep-alive: ['timeout=15, max=92']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854806</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain><record><id>3964717</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -261,41 +1593,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:19 GMT']
-      expires: ['Tue, 15 May 2018 21:08:19 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:01 GMT']
+      keep-alive: ['timeout=15, max=91']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>083b9e984e81e68fcfc149a8745f38cb</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:19 GMT']
-      expires: ['Tue, 15 May 2018 21:08:19 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:02 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:02 GMT']
+      keep-alive: ['timeout=15, max=90']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:02 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:02 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>3219fa3fab97032532638e67ef431d4c</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:19 GMT']
-      expires: ['Tue, 15 May 2018 21:08:19 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>3219fa3fab97032532638e67ef431d4c</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:20 GMT']
-      expires: ['Tue, 15 May 2018 21:08:20 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>3219fa3fab97032532638e67ef431d4c</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1663']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:20 GMT']
-      expires: ['Tue, 15 May 2018 21:08:20 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>ttl.fqdn</name><content>ttlshouldbe3600</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>3219fa3fab97032532638e67ef431d4c</ssid><domain>oldium.xyz</domain><record><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['513']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['419']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,41 +1428,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:20 GMT']
-      expires: ['Tue, 15 May 2018 21:08:20 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:03 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>3219fa3fab97032532638e67ef431d4c</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1798']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:20 GMT']
-      expires: ['Tue, 15 May 2018 21:08:20 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>14401225f5e94818c9a1c772c8bf4529</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:21 GMT']
-      expires: ['Tue, 15 May 2018 21:08:21 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:04 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:21 GMT']
-      expires: ['Tue, 15 May 2018 21:08:21 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1798']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:21 GMT']
-      expires: ['Tue, 15 May 2018 21:08:21 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken1</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['534']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['440']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:21 GMT']
-      expires: ['Tue, 15 May 2018 21:08:21 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:05 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['1954']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:22 GMT']
-      expires: ['Tue, 15 May 2018 21:08:22 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>_acme-challenge.listrecordset</name><content>challengetoken2</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid><domain>oldium.xyz</domain><record><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['534']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['440']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,41 +1494,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:22 GMT']
-      expires: ['Tue, 15 May 2018 21:08:22 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>14401225f5e94818c9a1c772c8bf4529</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:22 GMT']
-      expires: ['Tue, 15 May 2018 21:08:22 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:06 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_should_return_empty_list_if_no_records_found.yaml
@@ -1,91 +1,1406 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>7b51830ed7b1dfe943e03310c55965d0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:22 GMT']
-      expires: ['Tue, 15 May 2018 21:08:22 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>7b51830ed7b1dfe943e03310c55965d0</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:23 GMT']
-      expires: ['Tue, 15 May 2018 21:08:23 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:07 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>7b51830ed7b1dfe943e03310c55965d0</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:23 GMT']
-      expires: ['Tue, 15 May 2018 21:08:23 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_arguments_should_filter_list.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_arguments_should_filter_list.yaml
@@ -1,91 +1,1406 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>8c60e1fcd0e8f2da4f7bfdcb99b14e19</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:23 GMT']
-      expires: ['Tue, 15 May 2018 21:08:23 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:08 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>8c60e1fcd0e8f2da4f7bfdcb99b14e19</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:23 GMT']
-      expires: ['Tue, 15 May 2018 21:08:23 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>8c60e1fcd0e8f2da4f7bfdcb99b14e19</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:24 GMT']
-      expires: ['Tue, 15 May 2018 21:08:24 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:09 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>9f733677a6d40742d29f1f7e5caa7e8b</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:24 GMT']
-      expires: ['Tue, 15 May 2018 21:08:24 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>9f733677a6d40742d29f1f7e5caa7e8b</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:24 GMT']
-      expires: ['Tue, 15 May 2018 21:08:24 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>9f733677a6d40742d29f1f7e5caa7e8b</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2110']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:24 GMT']
-      expires: ['Tue, 15 May 2018 21:08:24 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fqdntest</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>9f733677a6d40742d29f1f7e5caa7e8b</ssid><domain>oldium.xyz</domain><record><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['519']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['425']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,41 +1428,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:25 GMT']
-      expires: ['Tue, 15 May 2018 21:08:25 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:10 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>9f733677a6d40742d29f1f7e5caa7e8b</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2251']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:25 GMT']
-      expires: ['Tue, 15 May 2018 21:08:25 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:11 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:11 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>99fa94f4962596fb865af4eaef3cbfb9</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:25 GMT']
-      expires: ['Tue, 15 May 2018 21:08:25 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>99fa94f4962596fb865af4eaef3cbfb9</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:26 GMT']
-      expires: ['Tue, 15 May 2018 21:08:26 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>99fa94f4962596fb865af4eaef3cbfb9</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2251']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:26 GMT']
-      expires: ['Tue, 15 May 2018 21:08:26 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:12 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.fulltest</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>99fa94f4962596fb865af4eaef3cbfb9</ssid><domain>oldium.xyz</domain><record><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['519']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['425']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,41 +1428,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:26 GMT']
-      expires: ['Tue, 15 May 2018 21:08:26 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:13 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:13 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>99fa94f4962596fb865af4eaef3cbfb9</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:26 GMT']
-      expires: ['Tue, 15 May 2018 21:08:26 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:13 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:13 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,91 +1,1406 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:14 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:14 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>6af20a3911dabc0e4bc6d6d1a96e129d</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:27 GMT']
-      expires: ['Tue, 15 May 2018 21:08:27 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:14 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:14 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>6af20a3911dabc0e4bc6d6d1a96e129d</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:27 GMT']
-      expires: ['Tue, 15 May 2018 21:08:27 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:15 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:15 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>6af20a3911dabc0e4bc6d6d1a96e129d</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:27 GMT']
-      expires: ['Tue, 15 May 2018 21:08:27 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:15 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:15 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:16 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:16 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>5a1a4c5f425903c92c106b48a8ae6aec</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:27 GMT']
-      expires: ['Tue, 15 May 2018 21:08:27 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:16 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:16 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a1a4c5f425903c92c106b48a8ae6aec</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:28 GMT']
-      expires: ['Tue, 15 May 2018 21:08:28 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a1a4c5f425903c92c106b48a8ae6aec</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2392']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:28 GMT']
-      expires: ['Tue, 15 May 2018 21:08:28 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>random.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a1a4c5f425903c92c106b48a8ae6aec</ssid><domain>oldium.xyz</domain><record><name>random.test</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['515']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['421']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,41 +1428,45 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:28 GMT']
-      expires: ['Tue, 15 May 2018 21:08:28 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:17 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>5a1a4c5f425903c92c106b48a8ae6aec</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:28 GMT']
-      expires: ['Tue, 15 May 2018 21:08:28 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:18 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:18 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,91 +1,1406 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:18 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:18 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>223cf8d00af71915b943441bace1b39a</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:29 GMT']
-      expires: ['Tue, 15 May 2018 21:08:29 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:19 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:19 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>223cf8d00af71915b943441bace1b39a</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:29 GMT']
-      expires: ['Tue, 15 May 2018 21:08:29 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:19 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:19 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>223cf8d00af71915b943441bace1b39a</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:29 GMT']
-      expires: ['Tue, 15 May 2018 21:08:29 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:20 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:20 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:20 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:20 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>68ebb34ed0330ac938d37af590af75fc</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:30 GMT']
-      expires: ['Tue, 15 May 2018 21:08:30 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:30 GMT']
-      expires: ['Tue, 15 May 2018 21:08:30 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2529']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:30 GMT']
-      expires: ['Tue, 15 May 2018 21:08:30 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain><record><name>orig.test</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['513']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['419']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,85 +1428,94 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:30 GMT']
-      expires: ['Tue, 15 May 2018 21:08:30 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:21 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854813</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964724</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2664']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:31 GMT']
-      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:22 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:22 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854813</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964724</id><name>orig.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2664']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:31 GMT']
-      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:22 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:22 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.test</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain><record><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['530']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['436']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -201,25 +1527,28 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:31 GMT']
-      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854813</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>68ebb34ed0330ac938d37af590af75fc</ssid><domain>oldium.xyz</domain><record><id>3964724</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -231,11 +1560,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:31 GMT']
-      expires: ['Tue, 15 May 2018 21:08:31 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      keep-alive: ['timeout=15, max=92']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:23 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:32 GMT']
-      expires: ['Tue, 15 May 2018 21:08:32 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:32 GMT']
-      expires: ['Tue, 15 May 2018 21:08:32 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2667']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:32 GMT']
-      expires: ['Tue, 15 May 2018 21:08:32 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.nameonly.test</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid><domain>oldium.xyz</domain><record><name>orig.nameonly.test</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['522']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['428']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,55 +1428,61 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:32 GMT']
-      expires: ['Tue, 15 May 2018 21:08:32 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:24 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2811']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:32 GMT']
-      expires: ['Tue, 15 May 2018 21:08:32 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:25 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:25 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Modify_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854815</id><type>TXT</type><content>updated</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Modify_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Modify_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>4bd1bfeeacd965063d8f24bf5cfd221c</ssid><domain>oldium.xyz</domain><record><id>3964726</id><type>TXT</type><content>updated</content><ttl>3600</ttl></record></ns0:Modify_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['506']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['412']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Modify_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -171,11 +1494,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:33 GMT']
-      expires: ['Tue, 15 May 2018 21:08:33 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:25 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:25 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:26 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:26 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:33 GMT']
-      expires: ['Tue, 15 May 2018 21:08:33 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:26 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:26 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:33 GMT']
-      expires: ['Tue, 15 May 2018 21:08:33 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2804']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:33 GMT']
-      expires: ['Tue, 15 May 2018 21:08:33 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfqdn</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain><record><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['517']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['423']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,85 +1428,94 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:34 GMT']
-      expires: ['Tue, 15 May 2018 21:08:34 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854816</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964727</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2943']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:34 GMT']
-      expires: ['Tue, 15 May 2018 21:08:34 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:27 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854816</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964727</id><name>orig.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2943']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:34 GMT']
-      expires: ['Tue, 15 May 2018 21:08:34 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:28 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:28 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.testfqdn</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain><record><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['534']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['440']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -201,25 +1527,28 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:35 GMT']
-      expires: ['Tue, 15 May 2018 21:08:35 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:28 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:28 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854816</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>0e36ceccb15ed6aa946ea93ff0a3ce7f</ssid><domain>oldium.xyz</domain><record><id>3964727</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -231,11 +1560,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:35 GMT']
-      expires: ['Tue, 15 May 2018 21:08:35 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:29 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:29 GMT']
+      keep-alive: ['timeout=15, max=92']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/subreg/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,105 +1,1422 @@
 interactions:
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Login xmlns=\"http://subreg.cz/types\">\n    <login>placeholder_auth_username</login><password>placeholder_auth_password</password></Login>\n</soap:Body>\n</soap:Envelope>"
+    body: null
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: GET
+    uri: https://subreg.cz/wsdl
+  response:
+    body: {string: !!python/unicode "<?xml version=\"1.0\"?>\n\t\t<definitions name=\"SubregCz\"\n\t\t\ttargetNamespace=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:tn=\"http://subreg.cz/wsdl\"\n\t\t\txmlns:ns=\"http://subreg.cz/types\"\n\t\t\txmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n\t\t\txmlns:soap=\"http://schemas.xmlsoap.org/wsdl/soap/\"\n\t\t\txmlns=\"http://schemas.xmlsoap.org/wsdl/\">\n\t\t<types>\n\t\t<xs:schema\n\t\t\ttargetNamespace=\"http://subreg.cz/types\"\n\t\t\txmlns=\"http://subreg.cz/types\">\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Login_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Login_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Login_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Login\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"login\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"password\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Login_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"lang_info\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\" type=\"Check_Domain_Params\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"amount_with_trustee\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"premium\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"existing_claim_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"price\"
+        type=\"Check_Domain_Price\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"digest\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"hosts\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"authid\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"premium\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"price\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Domain_CZ_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Domain_CZ_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"bill\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Options\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Info_Domain_CZ_Dsdata\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keygroup\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"quarantined\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contacts\"
+        type=\"Info_Domain_CZ_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Info_Domain_CZ_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"exDate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"crDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"trDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"upDate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"rgp\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"whoisproxy\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Info_Domain_CZ_Options\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Domains_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Domains_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Domains_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Domains_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domains\"
+        type=\"Domains_List_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Autorenew_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Autorenew_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Autorenew\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"autorenew\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Autorenew_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Create_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Create_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"disclose\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Create_Contact_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Create_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Create_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Create_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contactid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Update_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Update_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Update_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Update_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Update_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orders\" type=\"Update_Contact_Order\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Contact_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Contact_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Contact\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"contact\"
+        type=\"Info_Contact_Contact\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Contact_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"city\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"sp\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"cc\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"fax\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Contacts_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Contacts_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Contacts_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"surname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Contacts_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Contacts_List_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Check_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Check_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Check_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Check_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"avail\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Object_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Object_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Object\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"object\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"org\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"street\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"phone\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"vat\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"notify_email\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ident_number\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"hidden\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"host\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ip\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Nsset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Info_Object_Ns\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Dnskey\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"flags\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"protocol\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"alg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"pubKey\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Keyset\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnskey\" type=\"Info_Object_Dnskey\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"clID\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Object_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contact\" type=\"Info_Object_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"Info_Object_Nsset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"keyset\" type=\"Info_Object_Keyset\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Make_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Make_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contacts\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Host\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv4\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ipv6\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Ns\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"hosts\" type=\"Make_Order_Host\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nsset\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"admin\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"tech\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"billing\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Dsdata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tag\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"alg\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest_type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"digest\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"dsdata\" type=\"Make_Order_Dsdata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Params\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"period\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registrant\" type=\"Make_Order_Contact\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Make_Order_Contacts\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"Make_Order_Ns\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registry\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"authid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Make_Order_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"newowner\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nicd\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"password\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"hostname\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv4\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ipv6\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"dnstemp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"autorenew\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"object\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"params\"
+        type=\"Make_Order_Params\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Make_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"Make_Order_Order\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"orderid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Info_Order_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Info_Order_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Info_Order\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"order\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Order\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"lastupdate\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"payed\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\"
+        type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Order_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"Info_Order_Order\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Credit_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Credit_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Credit\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Credit\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"threshold\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Credit_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"Get_Credit_Credit\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Accountings_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Accountings_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Accountings\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Accounting\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"date\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"text\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"order\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sum\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"credit\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Accountings_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"from\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"to\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"accounting\" type=\"Get_Accountings_Accounting\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Client_Payment_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Client_Payment_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Client_Payment\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Client_Payment_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Credit_Correction_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Credit_Correction_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Credit_Correction\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"amount\" type=\"xs:decimal\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"reason\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Credit_Correction_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Pricelist_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"promo\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"promoexp\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"minyear_renew\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear_renew\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"local_presence\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element name=\"statuses\"
+        type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Pricelist_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element name=\"status\"
+        type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\" type=\"Prices_Data\"
+        minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\" type=\"Error_Info\"
+        minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Value\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"description\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"desc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"required\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"error_code\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"values\"
+        type=\"Prices_Value\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"continent\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"minyear\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"maxyear\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"local_presence\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prices\" type=\"Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"statuses\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Prices_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Get_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Get_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_Prices_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_Prices_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"value\"
+        type=\"xs:decimal\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_Prices\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pricelist\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\"
+        type=\"Set_Prices_Price\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_Prices_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Download_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Download_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Download_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Download_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Upload_Document_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Upload_Document_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Upload_Document\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"document\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Upload_Document_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"List_Documents_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"List_Documents_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"List_Documents\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Document\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"filetype\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"account\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"List_Documents_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"documents\" type=\"List_Documents_Document\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Users_List_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Users_List_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Users_List\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_User\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"username\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"credit\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"currency\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_name\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_street\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_city\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_pc\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"billing_country\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_id\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"company_vat\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"last_login\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Users_List_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"users\"
+        type=\"Users_List_User\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_ADD_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_ADD_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_ADD_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Anycast_Remove_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Anycast_Remove_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"server\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Anycast_Remove_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\"
+        type=\"Get_DNS_Zone_Record\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"template\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Set_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Set_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"records\" type=\"Set_DNS_Zone_Record\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Set_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Add_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Add_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"content\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prio\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"ttl\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Add_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Add_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Add_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Modify_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Modify_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"content\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"prio\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ttl\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Modify_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Modify_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Delete_DNS_Record_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Delete_DNS_Record_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Record\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"record\" type=\"Delete_DNS_Record_Record\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Delete_DNS_Record_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Get_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Get_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Get\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Get_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"count\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"date\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"id\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"orderstatus\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"message\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"POLL_Ack_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"POLL_Ack_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"POLL_Ack\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"id\" type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"POLL_Ack_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"OIB_Search_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"OIB_Search_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"OIB_Search\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"oib\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Domain\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"type\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Type\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"typedesc\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"used\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"maximum\" type=\"xs:integer\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"OIB_Search_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"domains\" type=\"OIB_Search_Domain\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"types\" type=\"OIB_Search_Type\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Certificate_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Certificate_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Certificate\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"orderid\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Certificate_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"certificate\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"expire\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_Redirects_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_Redirects_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_Redirects\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_Redirects_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"web\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"email\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"In_Subreg_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"In_Subreg_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"In_Subreg\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"In_Subreg_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"myaccount\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Sign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Sign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Sign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Unsign_DNS_Zone_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Unsign_DNS_Zone_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Unsign_DNS_Zone_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_DNS_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_DNS_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_DNS_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"domain\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnstype\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Anydata\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"data\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Dn\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"nameserver\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"anydata\" type=\"Get_DNS_Info_Anydata\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"nslist\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"soaid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_DNS_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"in_zone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dnssec\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dns\" type=\"Get_DNS_Info_Dn\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Special_Pricelist_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element
+        name=\"error\" type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Special_Pricelist_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Special_Pricelist\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Price\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"register\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"renew\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:decimal\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Pricelist\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"currency\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"dateto\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"prices\" type=\"Special_Pricelist_Price\"
+        minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Special_Pricelist_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"pricelist\" type=\"Special_Pricelist_Pricelist\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Response\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t<xs:element
+        name=\"status\" type=\"xs:string\"/>\n\t\t\t\t\t<xs:element name=\"data\"
+        type=\"Get_TLD_Info_Data\" minOccurs=\"0\" />\n\t\t\t\t\t<xs:element name=\"error\"
+        type=\"Error_Info\" minOccurs=\"0\" />\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info_Container\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t<xs:element
+        name=\"response\" type=\"Get_TLD_Info_Response\"/>\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:element
+        name=\"Get_TLD_Info\">\n\t\t\t\t<xs:complexType>\n\t\t\t\t\t<xs:sequence>\n\t\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"ssid\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"tld\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t\t</xs:sequence>\n\t\t\t\t</xs:complexType>\n\t\t\t</xs:element>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"type\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cnt\" type=\"xs:integer\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Option\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"value\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Param\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"param\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"desc\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"required\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"options\" type=\"Get_TLD_Info_Option\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Get_TLD_Info_Data\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"periodsCreate\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"periodsRenew\" type=\"xs:string\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"transfer\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trade\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"idn\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"trustee\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"ns\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"contacts\" type=\"Get_TLD_Info_Contact\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"params\" type=\"Get_TLD_Info_Param\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Codes\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"major\" type=\"xs:integer\"/>\n\t\t\n\t\t\t<xs:element name=\"minor\"
+        type=\"xs:integer\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Error_Info\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"errormsg\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"errorcode\"
+        type=\"Error_Codes\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Info_Domain_CZ_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"subregid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"registryid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact_New\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"name\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"surname\"
+        type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"org\" type=\"xs:string\"
+        minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element name=\"street\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"city\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"pc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"sp\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"cc\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element name=\"phone\" type=\"xs:string\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"fax\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"email\" type=\"xs:string\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t\t<xs:complexType
+        name=\"Make_Order_Contact\">\n\t\t\t\t<xs:sequence>\n\t\t\t\t\t\n\t\t\t<xs:element
+        name=\"id\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"regid\" type=\"xs:string\" minOccurs=\"0\"/>\n\t\t\n\t\t\t<xs:element
+        name=\"new\" type=\"Make_Order_Contact_New\" minOccurs=\"0\"/>\n\t\t\n\t\t\t\t</xs:sequence>\n\t\t\t</xs:complexType>\n\t\t\n\t\t</xs:schema>\n\t\t</types>\n\t\t\n\t\t\t<message
+        name=\"Login_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Login\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Login_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Login_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Domain_CZ_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Domain_CZ\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Domain_CZ_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Domain_CZ_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Domains_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Domains_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Domains_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Domains_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Autorenew_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Autorenew\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Autorenew_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Autorenew_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Create_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Create_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Create_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Create_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Update_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Update_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Update_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Update_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Contact_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Contact\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Contact_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Contact_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Contacts_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Contacts_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Contacts_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Contacts_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Check_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Check_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Check_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Check_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Object_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Object\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Object_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Object_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Make_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Make_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Make_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Make_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Info_Order_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Info_Order\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Info_Order_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Info_Order_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Credit_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Credit\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Credit_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Credit_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Accountings_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Accountings\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Accountings_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Accountings_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Client_Payment_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Client_Payment\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Client_Payment_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Client_Payment_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Credit_Correction_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Credit_Correction\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Credit_Correction_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Credit_Correction_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_Prices_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_Prices\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_Prices_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_Prices_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Download_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Download_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Download_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Download_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Upload_Document_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Upload_Document\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Upload_Document_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Upload_Document_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"List_Documents_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:List_Documents\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"List_Documents_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:List_Documents_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Users_List_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Users_List\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Users_List_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Users_List_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_ADD_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_ADD_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_ADD_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_ADD_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Anycast_Remove_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Anycast_Remove_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Anycast_Remove_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Anycast_Remove_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Set_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Set_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Set_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Set_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Add_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Add_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Add_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Add_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Modify_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Modify_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Modify_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Modify_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Delete_DNS_Record_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Delete_DNS_Record\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Delete_DNS_Record_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Delete_DNS_Record_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Get_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Get\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Get_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Get_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"POLL_Ack_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:POLL_Ack\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"POLL_Ack_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:POLL_Ack_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"OIB_Search_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:OIB_Search\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"OIB_Search_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:OIB_Search_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Certificate_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Certificate\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Certificate_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Certificate_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_Redirects_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_Redirects\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_Redirects_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_Redirects_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"In_Subreg_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:In_Subreg\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"In_Subreg_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:In_Subreg_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Sign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Sign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Sign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Sign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Unsign_DNS_Zone_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Unsign_DNS_Zone\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Unsign_DNS_Zone_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Unsign_DNS_Zone_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_DNS_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_DNS_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_DNS_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_DNS_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Special_Pricelist_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Special_Pricelist\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Special_Pricelist_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Special_Pricelist_Container\" />\n\t\t\t</message>\n\t\t\n\t\t\t<message
+        name=\"Get_TLD_Info_Message\">\n\t\t\t\t<part name=\"parameters\" element=\"ns:Get_TLD_Info\"
+        />\n\t\t\t</message>\n\t\t\t<message name=\"Get_TLD_Info_Response_Message\">\n\t\t\t\t<part
+        name=\"parameters\" element=\"ns:Get_TLD_Info_Container\" />\n\t\t\t</message>\n\t\t\n\t\t<portType
+        name=\"SubregCz\">\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<input
+        message=\"tn:Login_Message\" />\n\t\t\t\t<output message=\"tn:Login_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Domain\">\n\t\t\t\t<input
+        message=\"tn:Check_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Check_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Domain_CZ\">\n\t\t\t\t<input
+        message=\"tn:Info_Domain_CZ_Message\" />\n\t\t\t\t<output message=\"tn:Info_Domain_CZ_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Domains_List\">\n\t\t\t\t<input
+        message=\"tn:Domains_List_Message\" />\n\t\t\t\t<output message=\"tn:Domains_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Autorenew\">\n\t\t\t\t<input
+        message=\"tn:Set_Autorenew_Message\" />\n\t\t\t\t<output message=\"tn:Set_Autorenew_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Create_Contact\">\n\t\t\t\t<input
+        message=\"tn:Create_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Create_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Update_Contact\">\n\t\t\t\t<input
+        message=\"tn:Update_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Update_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Contact\">\n\t\t\t\t<input
+        message=\"tn:Info_Contact_Message\" />\n\t\t\t\t<output message=\"tn:Info_Contact_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Contacts_List\">\n\t\t\t\t<input
+        message=\"tn:Contacts_List_Message\" />\n\t\t\t\t<output message=\"tn:Contacts_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Check_Object\">\n\t\t\t\t<input
+        message=\"tn:Check_Object_Message\" />\n\t\t\t\t<output message=\"tn:Check_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Object\">\n\t\t\t\t<input
+        message=\"tn:Info_Object_Message\" />\n\t\t\t\t<output message=\"tn:Info_Object_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Make_Order\">\n\t\t\t\t<input
+        message=\"tn:Make_Order_Message\" />\n\t\t\t\t<output message=\"tn:Make_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Info_Order\">\n\t\t\t\t<input
+        message=\"tn:Info_Order_Message\" />\n\t\t\t\t<output message=\"tn:Info_Order_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Credit\">\n\t\t\t\t<input
+        message=\"tn:Get_Credit_Message\" />\n\t\t\t\t<output message=\"tn:Get_Credit_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Accountings\">\n\t\t\t\t<input
+        message=\"tn:Get_Accountings_Message\" />\n\t\t\t\t<output message=\"tn:Get_Accountings_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Client_Payment\">\n\t\t\t\t<input
+        message=\"tn:Client_Payment_Message\" />\n\t\t\t\t<output message=\"tn:Client_Payment_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Credit_Correction\">\n\t\t\t\t<input
+        message=\"tn:Credit_Correction_Message\" />\n\t\t\t\t<output message=\"tn:Credit_Correction_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Prices\">\n\t\t\t\t<input
+        message=\"tn:Prices_Message\" />\n\t\t\t\t<output message=\"tn:Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Get_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Get_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_Prices\">\n\t\t\t\t<input
+        message=\"tn:Set_Prices_Message\" />\n\t\t\t\t<output message=\"tn:Set_Prices_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Download_Document\">\n\t\t\t\t<input
+        message=\"tn:Download_Document_Message\" />\n\t\t\t\t<output message=\"tn:Download_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Upload_Document\">\n\t\t\t\t<input
+        message=\"tn:Upload_Document_Message\" />\n\t\t\t\t<output message=\"tn:Upload_Document_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"List_Documents\">\n\t\t\t\t<input
+        message=\"tn:List_Documents_Message\" />\n\t\t\t\t<output message=\"tn:List_Documents_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Users_List\">\n\t\t\t\t<input
+        message=\"tn:Users_List_Message\" />\n\t\t\t\t<output message=\"tn:Users_List_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_ADD_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_ADD_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_ADD_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Anycast_Remove_Zone\">\n\t\t\t\t<input
+        message=\"tn:Anycast_Remove_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Anycast_Remove_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Set_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Set_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Set_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Add_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Add_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Add_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Modify_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Modify_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Modify_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Delete_DNS_Record\">\n\t\t\t\t<input
+        message=\"tn:Delete_DNS_Record_Message\" />\n\t\t\t\t<output message=\"tn:Delete_DNS_Record_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Get\">\n\t\t\t\t<input
+        message=\"tn:POLL_Get_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Get_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"POLL_Ack\">\n\t\t\t\t<input
+        message=\"tn:POLL_Ack_Message\" />\n\t\t\t\t<output message=\"tn:POLL_Ack_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"OIB_Search\">\n\t\t\t\t<input
+        message=\"tn:OIB_Search_Message\" />\n\t\t\t\t<output message=\"tn:OIB_Search_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Certificate\">\n\t\t\t\t<input
+        message=\"tn:Get_Certificate_Message\" />\n\t\t\t\t<output message=\"tn:Get_Certificate_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_Redirects\">\n\t\t\t\t<input
+        message=\"tn:Get_Redirects_Message\" />\n\t\t\t\t<output message=\"tn:Get_Redirects_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"In_Subreg\">\n\t\t\t\t<input
+        message=\"tn:In_Subreg_Message\" />\n\t\t\t\t<output message=\"tn:In_Subreg_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Sign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Sign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Sign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Unsign_DNS_Zone\">\n\t\t\t\t<input
+        message=\"tn:Unsign_DNS_Zone_Message\" />\n\t\t\t\t<output message=\"tn:Unsign_DNS_Zone_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_DNS_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_DNS_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_DNS_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Special_Pricelist\">\n\t\t\t\t<input
+        message=\"tn:Special_Pricelist_Message\" />\n\t\t\t\t<output message=\"tn:Special_Pricelist_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t\t<operation name=\"Get_TLD_Info\">\n\t\t\t\t<input
+        message=\"tn:Get_TLD_Info_Message\" />\n\t\t\t\t<output message=\"tn:Get_TLD_Info_Response_Message\"
+        />\n\t\t\t</operation>\n\t\t\n\t\t</portType>\n\t\t<binding name=\"SubregCzBinding\"
+        type=\"tn:SubregCz\">\n\t\t\t<soap:binding style=\"document\" transport=\"http://schemas.xmlsoap.org/soap/http\"
+        />\n\t\t\n\t\t\t<operation name=\"Login\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Login\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Domain_CZ\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Domain_CZ\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Domains_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Domains_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Autorenew\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Autorenew\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Create_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Create_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Update_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Update_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Contact\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Contact\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Contacts_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Contacts_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Check_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Check_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Object\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Object\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Make_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Make_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Info_Order\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Info_Order\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Credit\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Credit\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Accountings\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Accountings\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Client_Payment\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Client_Payment\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Credit_Correction\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Credit_Correction\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_Prices\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_Prices\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Download_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Download_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Upload_Document\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Upload_Document\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"List_Documents\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#List_Documents\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Users_List\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Users_List\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_ADD_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_ADD_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Anycast_Remove_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Anycast_Remove_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Set_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Set_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Add_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Add_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Modify_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Modify_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Delete_DNS_Record\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Delete_DNS_Record\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Get\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Get\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"POLL_Ack\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#POLL_Ack\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"OIB_Search\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#OIB_Search\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Certificate\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Certificate\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_Redirects\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_Redirects\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"In_Subreg\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#In_Subreg\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Sign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Sign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Unsign_DNS_Zone\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Unsign_DNS_Zone\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_DNS_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_DNS_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Special_Pricelist\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Special_Pricelist\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t\t<operation
+        name=\"Get_TLD_Info\">\n\t\t\t\t<soap:operation soapAction=\"http://subreg.cz/wsdl#Get_TLD_Info\"
+        />\n\t\t\t\t<input>\n\t\t\t\t\t<soap:body use=\"literal\" />\n\t\t\t\t</input>\n\t\t\t\t<output>\n\t\t\t\t\t<soap:body
+        use=\"literal\" />\n\t\t\t\t</output>\n\t\t\t</operation>\n\t\t\n\t\t</binding>\n\t\t<service
+        name=\"SubregCzService\">\n\t\t\t<documentation>Subreg.CZ domain name services</documentation>\n\t\t\t<port
+        name=\"SubregCz\" binding=\"tn:SubregCzBinding\">\n\t\t\t\t<soap:address location=\"https://subreg.cz/soap/cmd.php?soap_format=1\"
+        />\n\t\t\t</port>\n\t\t</service>\n\t\t</definitions>\n\t\n"}
+    headers:
+      cache-control: [max-age=0]
+      connection: [Keep-Alive]
+      content-type: [text/xml]
+      date: ['Thu, 12 Jul 2018 07:47:29 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:29 GMT']
+      keep-alive: ['timeout=15, max=100']
+      server: [Apache]
+      transfer-encoding: [chunked]
+      x-powered-by: [PHP/5.4.45-0+deb7u2]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Login
+      xmlns:ns0="http://subreg.cz/types"><login>placeholder_auth_username</login><password>placeholder_auth_password</password></ns0:Login></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Login"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>123456789abcdef0123456789abcdef0</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Login_Container><response><status>ok</status><data><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid></data></response></ns1:Login_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['345']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:35 GMT']
-      expires: ['Tue, 15 May 2018 21:08:35 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      keep-alive: ['timeout=15, max=99']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Domains_List xmlns=\"http://subreg.cz/types\">\n    <ssid>123456789abcdef0123456789abcdef0</ssid></Domains_List>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Domains_List
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid></ns0:Domains_List></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['379']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['285']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Domains_List"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.net</name><expire>2023-10-20</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Domains_List_Container><response><status>ok</status><data><count>1</count><domains><name>oldium.xyz</name><expire>2023-06-29</expire><autorenew>0</autorenew></domains></data></response></ns1:Domains_List_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['423']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:35 GMT']
-      expires: ['Tue, 15 May 2018 21:08:35 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      keep-alive: ['timeout=15, max=98']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964728</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['2946']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:36 GMT']
-      expires: ['Tue, 15 May 2018 21:08:36 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      keep-alive: ['timeout=15, max=97']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>orig.testfull</name><content>challengetoken</content><ttl>3600</ttl></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain><record><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['517']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['423']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -111,85 +1428,94 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:36 GMT']
-      expires: ['Tue, 15 May 2018 21:08:36 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:30 GMT']
+      keep-alive: ['timeout=15, max=96']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854818</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964729</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964728</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['3085']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:37 GMT']
-      expires: ['Tue, 15 May 2018 21:08:37 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      keep-alive: ['timeout=15, max=95']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Get_DNS_Zone xmlns=\"http://subreg.cz/types\">\n    <domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Get_DNS_Zone>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Get_DNS_Zone
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain></ns0:Get_DNS_Zone></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['406']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['312']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Get_DNS_Zone"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8"?>
 
         <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.net</domain><records><id>3854792</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854791</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854815</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854818</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854810</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854811</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854812</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854807</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854814</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854817</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854796</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854797</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854804</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854793</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854794</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854809</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854808</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854798</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3854795</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
+        xmlns:ns1="http://subreg.cz/types"><SOAP-ENV:Body><ns1:Get_DNS_Zone_Container><response><status>ok</status><data><domain>oldium.xyz</domain><records><id>3964703</id><name>docs</name><type>CNAME</type><content>docs.example.com</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964702</id><name>localhost</name><type>A</type><content>127.0.0.1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964726</id><name>orig.nameonly.test</name><type>TXT</type><content>updated</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964729</id><name>orig.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964721</id><name>random.fqdntest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964722</id><name>random.fulltest</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964723</id><name>random.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964718</id><name>ttl.fqdn</name><type>TXT</type><content>ttlshouldbe3600</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964725</id><name>updated.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964728</id><name>updated.testfqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964707</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964708</id><name>_acme-challenge.createrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964715</id><name>_acme-challenge.deleterecordinset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964704</id><name>_acme-challenge.fqdn</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964705</id><name>_acme-challenge.full</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964720</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken2</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964719</id><name>_acme-challenge.listrecordset</name><type>TXT</type><content>challengetoken1</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964709</id><name>_acme-challenge.noop</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records><records><id>3964706</id><name>_acme-challenge.test</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></records></data></response></ns1:Get_DNS_Zone_Container></SOAP-ENV:Body></SOAP-ENV:Envelope>
 
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['3085']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:37 GMT']
-      expires: ['Tue, 15 May 2018 21:08:37 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      keep-alive: ['timeout=15, max=94']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Add_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><type>TXT</type><name>updated.testfull</name><content>challengetoken</content><ttl>3600</ttl><prio>0</prio></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Add_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Add_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain><record><name>updated.testfull</name><type>TXT</type><content>challengetoken</content><prio>0</prio><ttl>3600</ttl></record></ns0:Add_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['534']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['440']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Add_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -201,25 +1527,28 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['312']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:38 GMT']
-      expires: ['Tue, 15 May 2018 21:08:38 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:31 GMT']
+      keep-alive: ['timeout=15, max=93']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}
 - request:
-    body: !!python/unicode "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap:Envelope
-      xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"
-      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n<soap:Header/>\n<soap:Body>\n
-      \   <Delete_DNS_Record xmlns=\"http://subreg.cz/types\">\n    <record><id>3854818</id></record><domain>oldium.net</domain><ssid>123456789abcdef0123456789abcdef0</ssid></Delete_DNS_Record>\n</soap:Body>\n</soap:Envelope>"
+    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:Delete_DNS_Record
+      xmlns:ns0="http://subreg.cz/types"><ssid>78aa7a5a67e86fe3ee6e76b2d73ac765</ssid><domain>oldium.xyz</domain><record><id>3964729</id></record></ns0:Delete_DNS_Record></soap-env:Body></soap-env:Envelope>'
     headers:
-      Connection: [close]
-      Content-Length: ['449']
-      Content-Type: [text/xml; charset="UTF-8"]
-      Host: [subreg.cz]
-      User-Agent: [Python-urllib/2.7]
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['355']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://subreg.cz/wsdl#Delete_DNS_Record"']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
     method: POST
     uri: https://subreg.cz/soap/cmd.php?soap_format=1
   response:
@@ -231,11 +1560,12 @@ interactions:
 '}
     headers:
       cache-control: [max-age=0]
-      connection: [close]
+      connection: [Keep-Alive]
       content-length: ['311']
       content-type: [text/xml; charset=utf-8]
-      date: ['Tue, 15 May 2018 21:08:38 GMT']
-      expires: ['Tue, 15 May 2018 21:08:38 GMT']
+      date: ['Thu, 12 Jul 2018 07:47:32 GMT']
+      expires: ['Thu, 12 Jul 2018 07:47:32 GMT']
+      keep-alive: ['timeout=15, max=92']
       server: [Apache]
       x-powered-by: [PHP/5.4.45-0+deb7u2]
     status: {code: 200, message: OK}

--- a/tests/providers/test_subreg.py
+++ b/tests/providers/test_subreg.py
@@ -1,8 +1,8 @@
 # Test for one implementation of the interface
+
 from lexicon.providers.subreg import Provider
 from integration_tests import IntegrationTests
 from unittest import TestCase
-import pytest
 
 # Hook into testing framework by inheriting unittest.TestCase and reuse
 # the tests which *each and every* implementation of the interface must
@@ -11,4 +11,4 @@ class SubregProviderTests(TestCase, IntegrationTests):
 
     Provider = Provider
     provider_name = 'subreg'
-    domain = 'oldium.net'
+    domain = 'oldium.xyz'


### PR DESCRIPTION
PySimpleSOAP ignores certificate errors, so is basically unsecure. Zeep does server certificate verification during SSL setup, so use it instead.

The Zeep library in addition to PySimpleSOAP downloads the WSDL SOAP API description from the URL during instantiation. Alternative would be to supply our own pre-downloaded WSDL and use the Zeep cache feature to simulate already-downloaded file. But for now, keep it simple and let the WSDL be downloaded.