### PR TITLE
[Gehirn Web Service] fix 400 response on GET request

### DIFF
--- a/lexicon/providers/gehirn.py
+++ b/lexicon/providers/gehirn.py
@@ -314,7 +314,7 @@ class Provider(BaseProvider):
             query_string = json.dumps(query_params)
 
         r = requests.request(action, self.api_endpoint + url, params=query_string,
-                             data=json.dumps(data),
+                             data=json.dumps(data) if data else None,
                              headers=default_headers,
                              auth=default_auth)
         try:


### PR DESCRIPTION
If there is data at the time of GET request, it will result in 400 error.
I changed to include no payload in the request if data is empty.

```
Traceback (most recent call last):
  File "lexicon/__main__.py", line 136, in <module>
    main()
  File "lexicon/__main__.py", line 131, in main
    results = client.execute()
  File "/Users/chibiegg/lexicon/lexicon/client.py", line 38, in execute
    self.provider.authenticate()
  File "/Userschibiegg/lexicon/lexicon/providers/gehirn.py", line 56, in authenticate
    payload = self._get('/zones')
  File "/Users/chibiegg/lexicon/lexicon/providers/base.py", line 73, in _get
    return self._request('GET', url, query_params=query_params)
  File "/Users/chibiegg/lexicon/lexicon/providers/gehirn.py", line 322, in _request
    r.raise_for_status()
  File "/Users/chibiegg/.pyenv/versions/lexicon/lib/python3.6/site-packages/requests/models.py", line 939, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.gis.gehirn.jp/dns/v1/zones
```