### PR TITLE
Correct mocking in ovh unit tests during authentication phase

### DIFF
--- a/lexicon/providers/ovh.py
+++ b/lexicon/providers/ovh.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__name__)
 ENDPOINTS = {
     'ovh-eu': 'https://eu.api.ovh.com/1.0',
     'ovh-ca': 'https://ca.api.ovh.com/1.0',
+    'ovh-us': 'https://api.ovhcloud.com/1.0',
     'kimsufi-eu': 'https://eu.api.kimsufi.com/1.0',
     'kimsufi-ca': 'https://ca.api.kimsufi.com/1.0',
     'soyoustart-eu': 'https://eu.api.soyoustart.com/1.0',
@@ -48,6 +49,7 @@ class Provider(BaseProvider):
         self.domain_id = None
         self.endpoint_api = ENDPOINTS.get(self.options.get('auth_entrypoint'))
 
+    def authenticate(self):
         # All requests will be done in one HTTPS session
         self.session = requests.Session()
 
@@ -55,7 +57,7 @@ class Provider(BaseProvider):
         server_time = self.session.get('{0}/auth/time'.format(self.endpoint_api)).json()
         self.time_delta = server_time - int(time.time())
 
-    def authenticate(self):
+        # Get domain and status
         domain = self.options.get('domain')
 
         domains = self._get('/domain/zone/')


### PR DESCRIPTION
This PR extracts the modifications concerning OVH provider from #274 as discussed.

Following certbot/certbot#6222: I moved the logic involving a request to the OVH API from the provider constructor to the authenticate method implemented by the provider. Indeed, unit tests done in certbot using lexicon require to mock the HTTP requests, but the logic inside the provider constructor cannot be mocked. Therefore, any unit tests for certbot executed on a machine without an internet access, were failing when OVH authenticator is invoked. This correction allows these requests to be correctly mocked, as they occur during the authentication phase.