### PR TITLE
Remove advertising about Python 3.3 EOL on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python 3.3 end of life occurred one year ago (2017-09-29). No maintained distribution use this version by default, on there is not automated test on it with Lexicon.

This PR removes the flag of Python 3.3 from the supported Programming Languages in setup.py, consumed by Pypi.

Regards,
Adrien Ferrand