### PR TITLE
Execute the basic env test during CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,27 +4,26 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = basic, py27, py34, py35, py36, py37
 usedevelop = True
 skip_missing_interpreters = True
 
-# basic install ensures that providers which require additional libraries do not break the CLI when not installed.
+# Basic env ensures that providers which require additional libraries do not break the CLI when not installed.
 [testenv:basic]
 passenv = CIRCLE_BRANCH
 commands =
-	lexicon --version
+    lexicon --version
 deps =
-	-rrequirements.txt
+    -rrequirements.txt
 
-
+# Normal env will run every test available for all providers.
 [testenv]
 passenv = CIRCLE_BRANCH
 commands =
-	lexicon --version
-	py.test tests --cov=lexicon --numprocesses=auto --dist=loadfile
-	coveralls
+    lexicon --version
+    py.test tests --cov=lexicon --numprocesses=auto --dist=loadfile
+    coveralls
 deps =
-	-rrequirements.txt
+    -rrequirements.txt
     -rtest-requirements.txt
     -roptional-requirements.txt
-


### PR DESCRIPTION
In this PR, I added the `basic` env in envlist for the Lexicon tox config file. So if tox is run without a env argument, it will execute:
* the `basic` env with current Python interpreter
* the relevant `pyXX` env for the current Python interpreter version.

The `basic` env ensures that a not installed optional dependency do not break Lexicon. And the CI will catch it sooner, during a PR instead of only during a release.