### PR TITLE
Add _filter_response method for VCR tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,11 @@ class FooProviderTests(TestCase, IntegrationTests):
 
 	def _filter_query_parameters(self):
 		return ['secret_key']
+
+	def _filter_response(self, response):
+		"""See `IntegrationTests._filter_response` for more information on how
+		to filter the provider response."""
+		return response
 ```
 
 Make sure to replace any instance of `foo` or `Foo` with your provider name.

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -23,6 +23,7 @@ def _vcr_integration_test(decorated):
     def wrapper(self):
         with provider_vcr.use_cassette(self._cassette_path('IntegrationTests/{0}.yaml'.format(decorated.__name__)),
                                         filter_headers=self._filter_headers(),
+                                        before_record_response=self._filter_response,
                                         filter_query_parameters=self._filter_query_parameters(),
                                         filter_post_data_parameters=self._filter_post_data_parameters()):
             decorated(self)
@@ -347,3 +348,17 @@ class IntegrationTests(object):
         return []
     def _filter_post_data_parameters(self):
         return []
+    def _filter_response(self, response):
+        """Filter any sensitive data out of the providers response. `response`
+        is a Python object with the same structure as all the response sections
+        in the YAML recordings at tests/fixtures/cassets/[provider]. For the
+        sake of sparing you some time the most important values are:
+
+        response['body']['string']: Contains the HTML or JSON response.
+        response['headers']: An object whose keys are HTTP header names
+                             e.g. response['headers']['content-length'].
+        response['status']: An object that contains 'code' and 'message'
+                            subkeys representing the HTTP status code and
+                            status message.
+        """
+        return response


### PR DESCRIPTION
Allow VCR provider tests to also filter sensitive data from the response of providers.

## Design decisions
Other than the request filtering methods [VCR.py](https://vcrpy.readthedocs.io/en/latest/advanced.html#custom-response-filtering) does not offer detailed response filtering methods. Instead it offers exactly [one method](https://vcrpy.readthedocs.io/en/latest/advanced.html#custom-response-filtering) with which you can modify any part of the response.

## Documentation
We describe the response object in the docstring of the [IntegrationTests._filter_response](https://github.com/AnalogJ/lexicon/blob/64e26ca9891909a260474cdf0cf63c093c4cb962/tests/providers/integration_tests.py#L351) method.
Additionally we extended the filter examples inside the [CONTRIBUTING.md](https://github.com/AnalogJ/lexicon/blob/master/CONTRIBUTING.md) file.