### PR TITLE
OVH provider: add proxy support

### DIFF
--- a/lexicon/providers/ovh.py
+++ b/lexicon/providers/ovh.py
@@ -206,9 +206,15 @@ class Provider(BaseProvider):
         ]).encode('utf-8'))
 
         # Sign the request
-        prepared_request.headers['X-Ovh-Signature'] = '$1$' + signature.hexdigest()
+        headers['X-Ovh-Signature'] = '$1$' + signature.hexdigest()
 
-        result = self.session.send(prepared_request)
+        result = self.session.request(
+            method=action,
+            url=target,
+            params=query_params,
+            data=body,
+            headers=headers
+        )
         result.raise_for_status()
 
         return result.json()


### PR DESCRIPTION
Use session.request instead of session.send to support proxy.

No regression in "py.test tests/providers/test_ovh.py".

This is a correction for #313 