### PR TITLE
Protect nslookup call against non-ANSI and non-UTF8 output

### DIFF
--- a/lexicon/providers/auto.py
+++ b/lexicon/providers/auto.py
@@ -44,13 +44,13 @@ def _get_ns_records_for_domain(domain):
     # Available both for Windows and Linux (if dnsutils is installed for the latter)
     try:
         output = subprocess.check_output(['nslookup', '-querytype=NS', domain],
-                                        stderr=subprocess.STDOUT)
+                                        stderr=subprocess.STDOUT, universal_newlines=True)
     except subprocess.CalledProcessError as e:
         if 'NXDOMAIN' in e.output:
             raise ValueError('Error, domain {0} could not be resolved.'.format(domain))
 
     pattern = re.compile(r'nameserver = (.*?)\.*{0}'.format(os.linesep))
-    match = pattern.findall(output.decode())
+    match = pattern.findall(output)
 
     if not match:
         raise ValueError('Error, could not find ns entries for domain {0}. '


### PR DESCRIPTION
In some circonstances, `nslookup` output on Windows may include non-ASCII characters. In this case, output decoding may fail, as it will use typically UTF-8 while output will most likely by encoded into CP-1252.

This PR takes advantage of `universal_newlines`, that, on top of converting newlines characters, will do the bad job for us and return an already decoded string.