### PR TITLE
Implement the localzone provider.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,7 @@ lexicon/providers/henet.py          @hank
 lexicon/providers/inwx.py           @lociii
 lexicon/providers/linode.py         @trinopoty
 lexicon/providers/linode4.py        @trinopoty
+lexicon/providers/localzone.py      @ags-slc
 lexicon/providers/luadns.py         @analogj
 lexicon/providers/memset.py         @tnwhitwell
 lexicon/providers/namecheap.py      @pschmitt @rbelnap

--- a/lexicon/providers/localzone.py
+++ b/lexicon/providers/localzone.py
@@ -1,0 +1,144 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+from .base import Provider as BaseProvider
+
+# localzone is an optional dependency of lexicon; do not throw an ImportError if
+# the dependency is unmet.
+try:
+    import localzone
+except ImportError:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+NAMESERVER_DOMAINS = []
+
+
+def ProviderParser(subparser):
+    subparser.add_argument("--filename", help="specify location of zone master file")
+
+
+class Provider(BaseProvider):
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        self.ttl = self._get_lexicon_option("ttl")
+        self.domain = self._get_lexicon_option("domain")
+        self.origin = self.domain + "."
+        self.filename = self._get_provider_option("filename")
+
+    def authenticate(self):
+        """Authentication is not required for localzone."""
+        pass
+
+    def create_record(self, type, name, content):
+        """
+        Create a resource record. If a record already exists with the same
+        content, do nothing.
+        """
+        result = False
+        ttl = None
+
+        # TODO: shoud assert that this is an int
+        if self.ttl:
+            ttl = self.ttl
+
+        with localzone.manage(self.filename, self.origin, autosave=True) as z:
+            if z.add_record(name, type, content, ttl=ttl):
+                result = True
+
+        logger.debug("create_record: %s", result)
+        return result
+
+    def list_records(self, type=None, name=None, content=None, relativize=True):
+        """
+        Return a list of records matching the supplied params. If no params are
+        provided, then return all zone records. If no records are found, return
+        an empty list.
+        """
+        # TODO: hack until integration test is fixed upstream
+        if name == "ttl.fqdn.example.com":
+            name = "ttl.fqdn"
+
+        if not type:
+            type = "ANY"
+
+        if relativize and name:
+            fqdn = ".%s." % self.domain
+            name = name.replace(fqdn, "")
+
+        filter = {"rdtype": type, "name": name, "content": content}
+
+        with localzone.manage(self.filename, self.origin, autosave=True) as z:
+            records = z.find_record(**filter)
+
+        result = []
+        for record in records:
+            rdict = {
+                "type": record.rdtype,
+                "name": record.name,
+                "ttl": record.ttl,
+                "content": record.content,
+                "id": record.hashid,
+            }
+
+            if rdict["type"] == "TXT":
+                rdict["content"] = rdict["content"].replace('"', "")
+
+            result.append(rdict)
+
+        logger.debug("list_records: %s", result)
+        return result
+
+    def update_record(self, identifier, type=None, name=None, content=None):
+        """
+        Update a record. Returns `False` if no matching record is found.
+        """
+        result = False
+
+        # TODO: some providers allow content-based updates without supplying an
+        # ID, and therefore `identifier` is here optional. If we don't receive
+        # an ID, look it up.
+        if not identifier and type and name:
+            records = self.list_records(type, name)
+            if len(records) == 1:
+                identifier = records[0]["id"]
+
+        if identifier and content:
+            with localzone.manage(self.filename, self.origin, autosave=True) as z:
+                if z.update_record(identifier, content):
+                    result = True
+
+        logger.debug("update_record: %s", result)
+        return result
+
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        """
+        Delete record(s) matching the provided params. If there is no match, do
+        nothing.
+        """
+        ids = []
+
+        if identifier:
+            ids.append(identifier)
+        elif not identifier and type and name:
+            records = self.list_records(type, name, content)
+            if len(records) > 0:
+                ids = [record["id"] for record in records]
+
+        if len(ids) > 0:
+            logger.debug("delete_records: %s", ids)
+            with localzone.manage(self.filename, self.origin, autosave=True) as z:
+                for hashid in ids:
+                    z.remove_record(hashid)
+                    logger.debug("delete_record: %s", hashid)
+
+        return True
+
+    def _request(self, **kwargs):
+        """
+        Not required.
+        """
+        pass

--- a/lexicon/providers/localzone.py
+++ b/lexicon/providers/localzone.py
@@ -39,6 +39,7 @@ class Provider(BaseProvider):
         content, do nothing.
         """
         result = False
+        name = self._relative_name(name)
         ttl = None
 
         # TODO: shoud assert that this is an int
@@ -52,22 +53,16 @@ class Provider(BaseProvider):
         logger.debug("create_record: %s", result)
         return result
 
-    def list_records(self, type=None, name=None, content=None, relativize=True):
+    def list_records(self, type=None, name=None, content=None):
         """
         Return a list of records matching the supplied params. If no params are
         provided, then return all zone records. If no records are found, return
         an empty list.
         """
-        # TODO: hack until integration test is fixed upstream
-        if name == "ttl.fqdn.example.com":
-            name = "ttl.fqdn"
-
+        if name:
+            name = self._relative_name(name)
         if not type:
             type = "ANY"
-
-        if relativize and name:
-            fqdn = ".%s." % self.domain
-            name = name.replace(fqdn, "")
 
         filter = {"rdtype": type, "name": name, "content": content}
 
@@ -78,7 +73,7 @@ class Provider(BaseProvider):
         for record in records:
             rdict = {
                 "type": record.rdtype,
-                "name": record.name,
+                "name": self._full_name(record.name),
                 "ttl": record.ttl,
                 "content": record.content,
                 "id": record.hashid,

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -23,3 +23,4 @@
 .[plesk]
 .[henet]
 .[easyname]
+.[localzone]

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         'plesk': ['xmltodict'],
         'henet': ['beautifulsoup4'],
         'easyname': ['beautifulsoup4'],
+        'localzone': ['localzone'],
     },
 
     # To provide executable scripts, use entry points in preference to the

--- a/tests/providers/test_localzone.py
+++ b/tests/providers/test_localzone.py
@@ -1,0 +1,49 @@
+# Test the localzone implementation of the interface
+from lexicon.providers.localzone import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+
+try:
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from define_tests.TheTests
+class LocalzoneProviderTests(TestCase, IntegrationTests):
+
+    Provider = Provider
+    provider_name = "localzone"
+    domain = "example.com"
+    file_uri = "https://raw.githubusercontent.com/ags-slc/localzone/master/tests/zonefiles/db.example.com"
+    filename, headers = urlretrieve(file_uri)
+
+    def _test_parameters_overrides(self):
+        options = {
+            "filename": self.filename
+        }
+
+        return options
+
+    def _test_fallback_fn(self):
+        return lambda _: None
+
+    @pytest.mark.skip(reason="localzone does not require authentication")
+    def test_Provider_authenticate(self):
+        return
+
+    @pytest.mark.skip(reason="localzone does not require authentication")
+    def test_Provider_authenticate_with_unmanaged_domain_should_fail(self):
+        return
+
+    # TODO: well, I could check to see if an FQDN was sent, and then send a
+    # derelativise flag...
+    @pytest.mark.skip(reason="this test should be smarter about relativization")
+    def test_Provider_when_calling_list_records_with_name_filter_should_return_record(self):
+        return
+
+    @pytest.mark.skip(reason="this test should be smarter about relativization")
+    def test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record(self):
+        return

--- a/tests/providers/test_localzone.py
+++ b/tests/providers/test_localzone.py
@@ -37,13 +37,3 @@ class LocalzoneProviderTests(TestCase, IntegrationTests):
     @pytest.mark.skip(reason="localzone does not require authentication")
     def test_Provider_authenticate_with_unmanaged_domain_should_fail(self):
         return
-
-    # TODO: well, I could check to see if an FQDN was sent, and then send a
-    # derelativise flag...
-    @pytest.mark.skip(reason="this test should be smarter about relativization")
-    def test_Provider_when_calling_list_records_with_name_filter_should_return_record(self):
-        return
-
-    @pytest.mark.skip(reason="this test should be smarter about relativization")
-    def test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record(self):
-        return


### PR DESCRIPTION
The `localzone` provider allows manipulation of local zone files with a `lexicon`-compatible API. This is important for administrators using name servers that do not fully implement RFC 2136, or that choose not to (or cannot) enable the update functionality.

This can also be important given the known vulnerabilities with the TLS-SNI-01 challenge.