### PR TITLE
add Infoblox Provider

### DIFF
--- a/lexicon/providers/infoblox.py
+++ b/lexicon/providers/infoblox.py
@@ -1,0 +1,331 @@
+from __future__ import absolute_import
+
+import logging
+import requests
+import json
+
+from builtins import object
+
+from lexicon.providers.base import Provider as BaseProvider
+from lexicon.config import ConfigResolver
+
+"""
+Notes on this Provider
+
+1. Make sure the NIOS Version support WAPI 2.6.1
+2. Have a valid Certificate from a public CA installed at the Infoblox
+
+Commandline examples:
+1. all parameters given:
+lexicon infoblox --ib-host myib.mydomain.tld --auth-user {username} --auth-psw {passwordd} --ib-view default create test.local A --content 10.10.10.11 --name lexicon1
+2. Parameters mixed with ENV
+LEXICON_INFOBLOX_AUTH_USER={user} LEXICON_INFOBLOX_AUTH_PSW={password} lexicon infoblox --ib-host myib.mydomain.tld --ib-view default create test.local A --content 10.10.10.11 --name lexicon1
+
+"""
+
+logger = logging.getLogger(__name__)
+NAMESERVER_DOMAINS = ['test.local.']
+# SOA and NS are not record types itself, but rather auto created depending on the Zone settings.
+# Either Primary Grid Member directly assigned to the zone, or through a ns_group
+# skipping for now
+'''
+Dictionary to map the record Type to different Infoblox specific values
+IB_TYPE2CONTENT = {
+    'type':['WAPI atribute field content','WAPI base URL per type','WAPI returnfields'],
+}
+'''
+IB_TYPE2CONTENT = {
+    'A':['ipv4addr','record:a',',ttl,use_ttl'],
+    'AAAA':['ipv6addr','record:aaaa',',ttl,use_ttl'],
+    'CNAME':['canonical','record:cname',',ttl,use_ttl'],
+    'MX':['mail_exchanger','record:mx',',ttl,use_ttl'],
+    #'NS':['nameserver','record:ns',''],
+    #'SOA':['nameserver','record:ns',''],
+    'TXT':['text','record:txt',',ttl,use_ttl'],
+    'SRV':['target','record:srv',',ttl,use_ttl'],
+}
+
+def ProviderParser(subparser):
+    subparser.add_argument('--auth-user', help='specify the user to access the Infoblox WAPI')
+    subparser.add_argument('--auth-psw', help='specify the password to access the Infoblox WAPI')
+    subparser.add_argument('--ib-view', default='default', help='specify DNS View to manage at the Infoblox')
+    subparser.add_argument('--ib-host', help='specify Infoblox Host exposing the WAPI')
+    subparser.add_argument('--srv-port', default=0, help='specify SRV port')
+    subparser.add_argument('--srv-weight', default=100, help='specify SRV weight')
+
+class Provider(BaseProvider):
+
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        # In Case .local. Domains are used, ignore the tldextract in client.py
+        # this will be used in test_infoblox.py as well
+        if self.config.resolve('lexicon:domain') in NAMESERVER_DOMAINS[0]:
+            self.domain = NAMESERVER_DOMAINS[0].rstrip('.')
+        self.domain_id = None
+        self.version_id = None
+        self.view = self._get_provider_option('ib_view')
+        self.session = requests.session()
+        self.session.auth = (self._get_provider_option('auth_user'), self._get_provider_option('auth_psw'))
+        self.version = '2.6.1' #WAPI version supported by NIOS 8.3 and above
+        self.session.headers.update({'Content-Type' : 'application/json'})
+        self.api_endpoint = 'https://{0}/wapi/v{1}/'.format(self._get_provider_option('ib_host'),self.version)
+
+    # Authenticate against provider,
+    # Make any requests required to get the domain's id for this provider, so it can be used in subsequent calls.
+    # Should throw an error if authentication fails for any reason, of if the domain does not exist.
+    def authenticate(self):
+        response = self.session.get('{0}zone_auth?fqdn={1}&view={2}'.format(self.api_endpoint, self.domain, self.view))
+        domains = response.json()
+        try:
+            self.domain_id = domains[0]['_ref']
+        except IndexError:
+            logger.error('Domain {0} not found in view'.format(self.domain))
+            raise Exception('Domain {0} not found in view'.format(self.domain))         
+
+    # Create record. If record already exists with the same content, do nothing'
+    def create_record(self, type, name, content):
+        if name:
+            name = self._fqdn_name(name)
+        else:
+            raise Exception('Name not specified, no FQDN could be build')
+        # Find existing records for all types
+        existing = []
+        for rrtype in IB_TYPE2CONTENT:
+            existing = existing + self.list_records(type=rrtype, name=name)
+        # we don't want to delete all existing A,AAAA,TXT,SRV,MX,NS records
+        # which can not co-exist with CNAMEs
+        if any(d['type'] == type for d in existing):
+            # no conflict in types
+            if any(d['content'] == content and d['type'] == type for d in existing):
+                # already exists
+                return True
+            elif type == 'CNAME':
+                # we found a CNAME entry; we update it with the new target
+                return self.update_record(existing[0]['id'], type, name, content)
+            else:
+                return self._create_record(type, name, content)
+        elif any(d['type'] == 'CNAME' and type != 'CNAME' for d in existing):
+            # we found a CNAME entry; we can delete it and create the requested type
+            if self.delete_record(identifier=existing[0]['id']):
+                return self._create_record(type, name, content)
+            else:
+                logger.error('Deleting record failed for:{0}'.format(existing[0]['id']))
+                return False
+        elif any(d['type'] != 'CNAME' and type == 'CNAME' for d in existing):
+            logger.error('CNAME requested, but other records already exists')
+            raise Exception('CNAME requested, but other records already exists')
+        else:
+            return self._create_record(type, name, content)
+
+    def _create_record(self, type, name, content):
+        if name:
+            name = self._fqdn_name(name)
+        else:
+            raise Exception('Name not specified, no FQDN could be build')
+        if type.upper() in IB_TYPE2CONTENT:
+            uri = '{0}{1}'.format(self.api_endpoint,
+                                  IB_TYPE2CONTENT[type.upper()][1],
+                                  )
+            payload = self._generate_payload(type, name, content)
+            try:
+                response = self.session.post(uri, data=json.dumps(payload))
+            except:
+                logger.error('Connection Error during create')
+                raise Exception('Connection Error')
+            if response.status_code == 201:
+                return True
+            else:
+                return False
+        else:
+            raise Exception('RR Type not supported by Infoblox')
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def list_records(self, type=None, name=None, content=None):
+        # Infoblox stores entries based on their type, if type is not specified look up all types
+        if not type:
+            records = []
+            for type in IB_TYPE2CONTENT:
+                records = records + self._list_records(type=type,name=name,content=content)
+            return records
+        else:
+            return self._list_records(type=type,name=name,content=content)
+
+    def _list_records(self, type=None, name=None, content=None):
+        #infoblox expect the fullname when looking it up without trailing dot
+        if name:
+            name = self._fqdn_name(name)
+        else:
+            name = self.domain
+        records = []
+        if type.upper() in IB_TYPE2CONTENT:
+            uri = '{0}{1}?name={2}&view={3}&_return_fields={4}{5}'.format(self.api_endpoint,
+                                                                    IB_TYPE2CONTENT[type.upper()][1],
+                                                                    name,
+                                                                    self.view,
+                                                                    IB_TYPE2CONTENT[type.upper()][0],
+                                                                    IB_TYPE2CONTENT[type.upper()][2]
+                                                                    )
+            try:
+                response = self.session.get(uri)
+            except:
+                raise Exception('Connection Error')    
+
+            results = response.json()
+            for result in results:
+                if content:
+                    #return exact match
+                    if str(content).lower() == str(result[IB_TYPE2CONTENT[type][0]]).lower():
+                        if result['use_ttl']:
+                            record = {
+                                'type': type,
+                                'name': name,
+                                'ttl': result['ttl'],
+                                'content': result[IB_TYPE2CONTENT[type][0]],
+                                'id' : result['_ref'],
+                            }
+                        else:
+                            record = {
+                                'type': type,
+                                'name': name,
+                                'ttl': 3600, # replace by Infoblox default TTL
+                                'content': result[IB_TYPE2CONTENT[type][0]],
+                                'id' : result['_ref'],
+                            }
+                        records.append(record)
+                else:
+                    #return any record
+                    if result['use_ttl']:
+                        record = {
+                            'type': type,
+                            'name': name,
+                            'ttl': result['ttl'],
+                            'content': result[IB_TYPE2CONTENT[type][0]],
+                            'id' : result['_ref'],
+                        }
+                    else:
+                        record = {
+                            'type': type,
+                            'name': name,
+                            'ttl': 3600, # replace by Infoblox default TTL
+                            'content': result[IB_TYPE2CONTENT[type][0]],
+                            'id' : result['_ref'],
+                        }
+                    records.append(record)
+            return records
+        else:
+            return records
+
+    # Update a record. Identifier must be specified.
+    def update_record(self, identifier, type=None, name=None, content=None):
+        if identifier:
+            return self._update_record(identifier=identifier,type=type,name=name,content=content)
+        else:
+            success = []
+            for record in self.list_records(type, name, content):
+                success.append(self._update_record(identifier=record['id'],type=type,name=name,content=content))
+            if False in success:
+                return False
+            else:
+                return True
+    def _update_record(self, identifier, type=None, name=None, content=None):
+        uri = '{0}{1}'.format(self.api_endpoint,
+                                  identifier,
+                                  )
+        payload = self._generate_payload(type, name, content)
+        # remove view and name from the payload, as they can not be updated
+        del payload['view']
+        del payload['name']
+        try:
+            response = self.session.put(uri, data=json.dumps(payload))
+        except:
+            logger.error('Connection Error during create')
+            raise Exception('Connection Error')
+        if response.status_code == 200:
+            return True
+        else:
+            return False 
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    # If an identifier is specified, use it, otherwise do a lookup using type, name and content.
+    def delete_record(self, identifier=None, type=None, name=None, content=None):
+        # Infoblox Object Identifier example:
+        # record:cname/ZG5zLmJpbmRfY25hbWUkLjIzLmRlLm1naS5sZXhpY29uNA:lexicon.domain.tld/view
+        if identifier:
+            return self._delete_record(identifier)
+        else:
+            success = []
+            for record in self.list_records(type, name, content):
+                success.append(self._delete_record(record['id']))
+            if False in success:
+                return False
+            else:
+                return True
+
+    def _delete_record(self, identifier=None):
+        if identifier:
+            uri = '{0}{1}'.format(self.api_endpoint,
+                                  identifier,
+                                  )
+            try:
+                response = self.session.delete(uri)
+            except:
+                logger.error('Connection Error during create')
+                raise Exception('Connection Error')
+            if response.status_code == 200:
+                return True
+            else:
+                return False
+        else:
+            return False 
+
+    #Helpers
+    def _generate_payload(self, type, name, content):
+        #build full object as required by Infoblox WAPI
+        payload = {}
+        payload['view'] = self.view
+        payload['name'] = name
+        if type.upper() == 'TXT':
+            payload[IB_TYPE2CONTENT[type.upper()][0]] = '"' + content + '"'
+        else:
+            payload[IB_TYPE2CONTENT[type.upper()][0]] = content
+        if self._get_lexicon_option('ttl'):
+            payload['ttl'] = self._get_lexicon_option('ttl')
+            payload['use_ttl'] = True
+        #MX and SRV have additional fields
+        if type.upper() == 'MX':
+            payload['preference'] = self._get_lexicon_option('priority')
+        elif type.upper() == 'SRV':
+            payload['priority'] = self._get_lexicon_option('priority')
+            payload['weight'] = self._get_provider_option('ib_weight')
+            payload['port'] = self._get_provider_option('ib_port')
+        return payload
+
+    def _fqdn_name(self, record_name):
+        record_name = record_name.rstrip('.') # strip trailing period from fqdn if present
+        #check if the record_name is fully specified
+        if not record_name.endswith(self.domain):
+            record_name = "{0}.{1}".format(record_name, self.domain)
+        return "{0}".format(record_name) #return the fqdn name without trailing dot
+
+    def _full_name(self, record_name):
+        record_name = record_name.rstrip('.') # strip trailing period from fqdn if present
+        #check if the record_name is fully specified
+        if not record_name.endswith(self.domain):
+            record_name = "{0}.{1}".format(record_name, self.domain)
+        return record_name
+
+    def _relative_name(self, record_name):
+        record_name = record_name.rstrip('.') # strip trailing period from fqdn if present
+        #check if the record_name is fully specified
+        if record_name.endswith(self.domain):
+            record_name = record_name[:-len(self.domain)]
+            record_name = record_name.rstrip('.')
+        return record_name
+
+    def _clean_TXT_record(self, record):
+        if record['type'] == 'TXT':
+            # some providers have quotes around the TXT records, so we're going to remove those extra quotes
+            record['content'] = record['content'][1:-1]
+        return record

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_authenticate.yaml
@@ -1,0 +1,27 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:23 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285924,timeout=3600,mtime=1542285924,su=1,auth=LOCAL,user=admin.nss,bhQRRmDSH4DUvHRlj5/hFr9QGfnWvDgbI4Y";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=thisisadomainidonotown.com&view=internal
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:24 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285925,timeout=3600,mtime=1542285925,su=1,auth=LOCAL,user=admin.nss,aAdYC7UO+bJ6xLghO5ZiRmA49bNEKfGuBws";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:25 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285926,timeout=3600,mtime=1542285926,su=1,auth=LOCAL,user=admin.nss,EjyGG0TQHVe7dBBc7/kDDkZ3Dy15Ak1Gze4";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=localhost.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:a/ZG5zLmJpbmRfYSQuMjMubG9jYWwudGVzdCxsb2NhbGhvc3QsMTI3LjAuMC4x:localhost.test.local/internal\"\
+        , \n        \"ipv4addr\": \"127.0.0.1\", \n        \"ttl\": 3600, \n     \
+        \   \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:26 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=localhost.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:26 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=localhost.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:26 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=localhost.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:27 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=localhost.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:27 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=localhost.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:27 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:27 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285928,timeout=3600,mtime=1542285928,su=1,auth=LOCAL,user=admin.nss,Jvd5eRW8djYzLZOwMV1HQ9hpMRwLbF/64ck";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=docs.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=docs.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=docs.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:cname/ZG5zLmJpbmRfY25hbWUkLjIzLmxvY2FsLnRlc3QuZG9jcw:docs.test.local/internal\"\
+        , \n        \"canonical\": \"docs.example.com\", \n        \"ttl\": 3600,\
+        \ \n        \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=docs.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=docs.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=docs.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:28 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285930,timeout=3600,mtime=1542285930,su=1,auth=LOCAL,user=admin.nss,bO5QtHHSvGAZsnf9eWxhHd3dBykhBR4VSNo";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZxZG4uX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.fqdn.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.fqdn.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:30 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285931,timeout=3600,mtime=1542285931,su=1,auth=LOCAL,user=admin.nss,aUUP5G+gEVKvuHUc6c2h4zWWOVwRzVpYOIk";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.full.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.full.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.full.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.full.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.full.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZ1bGwuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.full.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.full.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285931,timeout=3600,mtime=1542285931,su=1,auth=LOCAL,user=admin.nss,rfkvvqwNN4FrG0W40T4hnYH4IIDdwIQiUe8";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.test.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.test.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:31 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.test.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:32 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.test.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:32 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3QuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:32 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.test.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:32 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,287 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:32 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285933,timeout=3600,mtime=1542285933,su=1,auth=LOCAL,user=admin.nss,tpUXn1btCkuqVCx4oB+nOON+x7qrbdjmcRg";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmNyZWF0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.createrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmNyZWF0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.createrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmNyZWF0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.createrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmNyZWF0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.createrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.createrecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,306 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:33 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285934,timeout=3600,mtime=1542285934,su=1,auth=LOCAL,user=admin.nss,nhwoPl4+Eoj9rg6T1RRcJPH0l3EMg0Tio0Q";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.noop.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.noop.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.noop.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.noop.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.noop.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lm5vb3AuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.noop.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.noop.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.noop.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.noop.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.noop.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.noop.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.noop.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lm5vb3AuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.noop.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.noop.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.noop.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lm5vb3AuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbiI:_acme-challenge.noop.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:34 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285935,timeout=3600,mtime=1542285935,su=1,auth=LOCAL,user=admin.nss,ib9Aq+Bfynzv/gIo8LZg2F4BGMDKZb1ahrs";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=delete.testfilt.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=delete.testfilt.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=delete.testfilt.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=delete.testfilt.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfilt.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=delete.testfilt.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600, "name": "delete.testfilt.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmaWx0LmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfilt.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfilt.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmaWx0LmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfilt.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmaWx0LmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfilt.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmaWx0LmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfilt.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfilt.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:35 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285936,timeout=3600,mtime=1542285936,su=1,auth=LOCAL,user=admin.nss,23835N079Hq2EyGWXgAYm6a40k+cQVdMIFE";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=delete.testfqdn.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=delete.testfqdn.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=delete.testfqdn.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=delete.testfqdn.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=delete.testfqdn.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600, "name": "delete.testfqdn.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfqdn.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfqdn.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfqdn.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfqdn.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:36 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:37 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285938,timeout=3600,mtime=1542285938,su=1,auth=LOCAL,user=admin.nss,tuMcL6ANkeGcJX5ngaVKHWUj/jijz8BXbNo";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=delete.testfull.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=delete.testfull.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=delete.testfull.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=delete.testfull.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfull.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=delete.testfull.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600, "name": "delete.testfull.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['118']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfull.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfull.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfull.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfull.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLmRlbGV0ZS4iY2hhbGxlbmdldG9rZW4i:delete.testfull.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testfull.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:38 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285939,timeout=3600,mtime=1542285939,su=1,auth=LOCAL,user=admin.nss,b2m8oUqkFf+BNWkevprpjPzFpqI5QQWV9pI";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=delete.testid.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=delete.testid.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=delete.testid.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=delete.testid.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testid.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=delete.testid.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600, "name": "delete.testid.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['116']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RpZC5kZWxldGUuImNoYWxsZW5nZXRva2VuIg:delete.testid.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testid.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RpZC5kZWxldGUuImNoYWxsZW5nZXRva2VuIg:delete.testid.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RpZC5kZWxldGUuImNoYWxsZW5nZXRva2VuIg:delete.testid.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RpZC5kZWxldGUuImNoYWxsZW5nZXRva2VuIg:delete.testid.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=delete.testid.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:39 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,378 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:40 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285941,timeout=3600,mtime=1542285941,su=1,auth=LOCAL,user=admin.nss,1BzHgt99MtyM+YPTioo2zowTQV+H6DD9KL0";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4yIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken1\"", "use_ttl": true, "ttl":
+      3600, "name": "_acme-challenge.deleterecordinset.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['137']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4xIg:_acme-challenge.deleterecordinset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4xIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4yIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4xIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4yIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4xIg:_acme-challenge.deleterecordinset.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4xIg:_acme-challenge.deleterecordinset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordinset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZGluc2V0Ll9hY21lLWNoYWxsZW5nZS4iY2hhbGxlbmdldG9rZW4yIg:_acme-challenge.deleterecordinset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,417 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:41 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285943,timeout=3600,mtime=1542285943,su=1,auth=LOCAL,user=admin.nss,ET5bE6LymqUZxB47v+vNE22tj7Iu1e1cpX0";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken1\"", "use_ttl": true, "ttl":
+      3600, "name": "_acme-challenge.deleterecordset.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['135']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.deleterecordset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.deleterecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken2\"", "use_ttl": true, "ttl":
+      3600, "name": "_acme-challenge.deleterecordset.test.local", "view": "internal"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['135']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: POST
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.deleterecordset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 201, message: Created}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.deleterecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.deleterecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:43 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.deleterecordset.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMSI:_acme-challenge.deleterecordset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:44 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: DELETE
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.deleterecordset.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmRlbGV0ZXJlY29yZHNldC5fYWNtZS1jaGFsbGVuZ2UuImNoYWxsZW5nZXRva2VuMiI:_acme-challenge.deleterecordset.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:44 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.deleterecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:44 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:44 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285945,timeout=3600,mtime=1542285945,su=1,auth=LOCAL,user=admin.nss,eeSC1efOIt/UrBCTD+oXd9suENduUTKPRcw";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=ttl.fqdn.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=ttl.fqdn.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=ttl.fqdn.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=ttl.fqdn.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=ttl.fqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZxZG4udHRsLiJ0dGxzaG91bGRiZTM2MDAi:ttl.fqdn.test.local/internal\"\
+        , \n        \"text\": \"ttlshouldbe3600\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=ttl.fqdn.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=ttl.fqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZxZG4udHRsLiJ0dGxzaG91bGRiZTM2MDAi:ttl.fqdn.test.local/internal\"\
+        , \n        \"text\": \"ttlshouldbe3600\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,312 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:45 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285946,timeout=3600,mtime=1542285946,su=1,auth=LOCAL,user=admin.nss,HEaMqR/b7hgOcHqQI77aJzGhCRptGY6imGY";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjEi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjIi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjEi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjIi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:46 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=_acme-challenge.listrecordset.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjEi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken1\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }, \n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0Lmxpc3RyZWNvcmRzZXQuX2FjbWUtY2hhbGxlbmdlLiJjaGFsbGVuZ2V0b2tlbjIi:_acme-challenge.listrecordset.test.local/internal\"\
+        , \n        \"text\": \"challengetoken2\", \n        \"ttl\": 3600, \n   \
+        \     \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285947,timeout=3600,mtime=1542285947,su=1,auth=LOCAL,user=admin.nss,6oKbSvu9B3nKp7un2t2c4RlhLQC00tf+yZc";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=random.fqdntest.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=random.fqdntest.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=random.fqdntest.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=random.fqdntest.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.fqdntest.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZxZG50ZXN0LnJhbmRvbS4iY2hhbGxlbmdldG9rZW4i:random.fqdntest.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=random.fqdntest.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.fqdntest.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZxZG50ZXN0LnJhbmRvbS4iY2hhbGxlbmdldG9rZW4i:random.fqdntest.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:47 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285949,timeout=3600,mtime=1542285949,su=1,auth=LOCAL,user=admin.nss,voJKowzssCFkayOo+egRYc9rwDJgOV0PSKM";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=random.fulltest.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=random.fulltest.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=random.fulltest.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=random.fulltest.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.fulltest.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZ1bGx0ZXN0LnJhbmRvbS4iY2hhbGxlbmdldG9rZW4i:random.fulltest.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=random.fulltest.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.fulltest.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LmZ1bGx0ZXN0LnJhbmRvbS4iY2hhbGxlbmdldG9rZW4i:random.fulltest.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:49 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285950,timeout=3600,mtime=1542285950,su=1,auth=LOCAL,user=admin.nss,bENXqZnxDWOBQvftBiqUcYSHIqAbYyeg1g0";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=filter.thisdoesnotexist.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:50 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:50 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285951,timeout=3600,mtime=1542285951,su=1,auth=LOCAL,user=admin.nss,vntWjv38Uisuo/+cyUYFluSObsYur4nbYFg";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=random.test.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=random.test.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=random.test.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=random.test.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3QucmFuZG9tLiJjaGFsbGVuZ2V0b2tlbiI:random.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=random.test.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=random.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3QucmFuZG9tLiJjaGFsbGVuZ2V0b2tlbiI:random.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,153 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285951,timeout=3600,mtime=1542285951,su=1,auth=LOCAL,user=admin.nss,NVq9pjjLlezLnfpLNqXBgcd5lQ5Q63FCgng";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:51 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285952,timeout=3600,mtime=1542285952,su=1,auth=LOCAL,user=admin.nss,sUQjHKxySyPjuqlIfax2kkw/9orj61V+iKg";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=orig.test.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=orig.test.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=orig.test.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=orig.test.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3Qub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=orig.test.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3Qub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: PUT
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3Qub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.test.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3Qub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.test.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285952,timeout=3600,mtime=1542285952,su=1,auth=LOCAL,user=admin.nss,jdz4FPHLsF5GGS2mxNF23LsMCUcbm29avDc";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=orig.nameonly.test.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=orig.nameonly.test.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=orig.nameonly.test.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=orig.nameonly.test.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.nameonly.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3QubmFtZW9ubHkub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.nameonly.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=orig.nameonly.test.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.nameonly.test.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3QubmFtZW9ubHkub3JpZy4iY2hhbGxlbmdldG9rZW4i:orig.nameonly.test.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285952,timeout=3600,mtime=1542285952,su=1,auth=LOCAL,user=admin.nss,SdJcsmnKT5QFom/iJQa51ErWKoL6Af7LP1w";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=orig.testfqdn.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=orig.testfqdn.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=orig.testfqdn.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:52 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=orig.testfqdn.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.testfqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfqdn.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=orig.testfqdn.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.testfqdn.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfqdn.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: PUT
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfqdn.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmcWRuLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfqdn.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/infoblox/IntegrationTests/test_Provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/zone_auth?fqdn=test.local&view=internal
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"zone_auth/ZG5zLnpvbmUkLjIzLmxvY2FsLnRlc3Q:test.local/internal\"\
+        , \n        \"fqdn\": \"test.local\", \n        \"view\": \"internal\"\n \
+        \   }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      set-cookie: ['ibapauth="ip=164.61.224.80,client=API,group=admin-group,ctime=1542285953,timeout=3600,mtime=1542285953,su=1,auth=LOCAL,user=admin.nss,TDqeSDXO6x9jjFJA+UXbN6AALvoI+MqnV/Q";
+          httponly; Path=/; secure']
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:a?name=orig.testfull.test.local&view=internal&_return_fields=ipv4addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:aaaa?name=orig.testfull.test.local&view=internal&_return_fields=ipv6addr,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:cname?name=orig.testfull.test.local&view=internal&_return_fields=canonical,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:srv?name=orig.testfull.test.local&view=internal&_return_fields=target,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.testfull.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfull.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:mx?name=orig.testfull.test.local&view=internal&_return_fields=mail_exchanger,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode '[]'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: GET
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt?name=orig.testfull.test.local&view=internal&_return_fields=text,ttl,use_ttl
+  response:
+    body: {string: !!python/unicode "[\n    {\n        \"_ref\": \"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfull.test.local/internal\"\
+        , \n        \"text\": \"challengetoken\", \n        \"ttl\": 3600, \n    \
+        \    \"use_ttl\": true\n    }\n]"}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+- request:
+    body: !!python/unicode '{"text": "\"challengetoken\"", "use_ttl": true, "ttl":
+      3600}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['60']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.20.0]
+    method: PUT
+    uri: https://dns1.int.metro-cc.com/wapi/v2.6.1/record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfull.test.local/internal
+  response:
+    body: {string: !!python/unicode '"record:txt/ZG5zLmJpbmRfdHh0JC4yMy5sb2NhbC50ZXN0LnRlc3RmdWxsLm9yaWcuImNoYWxsZW5nZXRva2VuIg:orig.testfull.test.local/internal"'}
+    headers:
+      cache-control: ['no-cache, no-store']
+      connection: [Keep-Alive]
+      content-type: [application/json]
+      date: ['Thu, 15 Nov 2018 12:45:53 GMT']
+      keep-alive: [timeout=150]
+      pragma: [no-cache]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/providers/test_infoblox.py
+++ b/tests/providers/test_infoblox.py
@@ -1,0 +1,41 @@
+# Test for one implementation of the interface
+from lexicon.providers.infoblox import Provider
+from integration_tests import IntegrationTests
+from unittest import TestCase
+import pytest
+import os
+
+"""
+A note about running these tests against a Infoblox Environment
+
+1. Make sure the NIOS Version support WAPI 2.6.1
+2. Have a valid Certificate from a public CA installed at the Infoblox
+3. create a Authoritative zone test.local in a view (default if no views are created)
+4. create a User with permissions RW permissions for the zone test.local and enable the User for API
+
+Environment Variables work fine when envoking lexicon manualy
+LEXICON_INFOBLOX_AUTH_USER={user} LEXICON_INFOBLOX_AUTH_PSW={password} lexicon infoblox --ib-host dns1.int.metro-cc.com --ib-view internal create test.local A --content 10.10.10.11 --name lexicon1
+Invoking the py.test however fails
+LEXICON_LIVE_TESTS=true LEXICON_INFOBLOX_AUTH_USER={username} LEXICON_INFOBLOX_AUTH_PSW={password} py.test tests/providers/test_infoblox.py
+Both parameters are populated with:
+auth_user = placeholder_auth_user
+auth_psw = placeholder_auth_psw
+"""
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class InfobloxProviderTests(TestCase, IntegrationTests):
+
+	Provider = Provider
+	provider_name = 'infoblox'
+	domain = 'test.local'
+	 
+	def _test_parameters_overrides(self):
+		#workaround ENV problems during testing
+		env_user = os.environ.get('LEXICON_INFOBLOX_AUTH_USER', 'infoblox')
+		env_psw = os.environ.get('LEXICON_INFOBLOX_AUTH_PSW', 'default')
+		return {'ib_host': 'dns1.int.metro-cc.com', 'ib_view': 'internal', 'auth_user': env_user, 'auth_psw': env_psw}
+
+	def _filter_headers(self):
+		return ['Authorization', 'Cookie','set-cookie']


### PR DESCRIPTION
Dear AnalogJ,

we are using Infoblox within our company and would like to use the lexicon library in certbot later on.

As of now the provider does not handle NS / SOA records, since these records are not explicitly set, but rather implicitly created at the Infoblox System.


Right now v2.6.1 (NIOS 8.1.3 higher) is hard coded, but can be made an argument or discovered through an endpoint in the Infoblox API.
Infoblox running NIOS 6.12.27 or higher support the /?_schema to retrieve a list of all supported vesions.

Since Infoblox is a typical in-house solution the provider asks to specify a DNS view (if omitted it will use the Infoblox default view name "default").
For testing purposes a test.local domain was created to not interfere with any live data.

Best Regards
Jens


