### PR TITLE
[ConoHa] Fix: Authentication is not performed.

### DIFF
--- a/lexicon/providers/conoha.py
+++ b/lexicon/providers/conoha.py
@@ -41,7 +41,7 @@ class Provider(BaseProvider):
     # Should throw an error if authentication fails for any reason, of if the domain does not exist.
     def authenticate(self):
         self.auth_token = self._get_provider_option('auth_token')
-        if self.auth_token:
+        if not self.auth_token:
             if not (self._get_provider_option('auth_username')
                     and self._get_provider_option('auth_password')):
                 raise Exception(

--- a/tests/providers/test_conoha.py
+++ b/tests/providers/test_conoha.py
@@ -21,7 +21,7 @@ class ConohaProviderTests(TestCase, IntegrationTests):
         return {'region': 'tyo1'}
 
     def _test_fallback_fn(self):
-        return lambda x: None if x in ('priority', 'auth_token') else 'placeholder_' + x
+        return lambda x: None if x in ('priority') else 'placeholder_' + x
 
     def _filter_post_data_parameters(self):
         return ['auth']


### PR DESCRIPTION
ConoHa DNS provider didn't work well after https://github.com/AnalogJ/lexicon/commit/481d2f3adb5e1c936b45c6694a2a0f4369e621fc

Because of simple mistake: https://github.com/AnalogJ/lexicon/commit/481d2f3adb5e1c936b45c6694a2a0f4369e621fc#diff-c412918268f4e650cbb8b70784dcc2fbR37