### PR TITLE
Resolve provider_name during tests

### DIFF
--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -360,6 +360,7 @@ class IntegrationTests(object):
         # First we load the overrides
         overrides = self._test_parameters_overrides()
         overrides['domain'] = self.domain
+        overrides['provider_name'] = self.provider_name
         config.with_config_source(EngineOverrideConfigSource(overrides))
         
         # Then we get environment variables


### PR DESCRIPTION
Currently, integration tests are not able to feed configuration from environment variables (for instance `auth_token` for Clouflare using `LEXICON_CLOUDFLARE_AUTH_TOKEN`).

It is because `lexicon:provider_name` is not set in the `Config` object passed to the provider. This PR fixes that.