### PR TITLE
Improve & fix CLI output with non-list actions

### DIFF
--- a/lexicon/cli.py
+++ b/lexicon/cli.py
@@ -14,12 +14,12 @@ from lexicon.parser import generate_cli_main_parser
 logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 
-def generate_table_result(lexicon_logger, output=None, without_header=None):
-    """Convert returned JSON into a nice table for command line usage"""
+def generate_list_table_result(lexicon_logger, output=None, without_header=None):
+    """Convert returned data from list actions into a nice table for command line usage"""
     try:
-        _ = (entry for entry in output)
+        isinstance(output, dict)
     except TypeError:
-        lexicon_logger.debug('Command output is not iterable, and then cannot '
+        lexicon_logger.debug('Command output is not a dict, and then cannot '
                              'be printed with --quiet parameter not enabled.')
         return None
 
@@ -58,26 +58,43 @@ def generate_table_result(lexicon_logger, output=None, without_header=None):
         table.append(' '.join(row_list))
 
     # Return table
-    return '\n'.join(table)
+    return os.linesep.join(table)
 
 
-def handle_output(results, output_type):
+def generate_table_results(output=None, without_header=None):
+    """Convert returned data from non-list actions into a nice table for command line usage"""
+    array = []
+    str_output = str(output)
+
+    if not without_header:
+        array.append('RESULT')
+        array.append('-' * max(6, len(str_output)))
+
+    array.append(str_output)
+    return os.linesep.join(array)
+
+
+def handle_output(results, output_type, action):
     """Print the relevant output for given output_type"""
-    if not output_type == 'QUIET':
-        if not output_type == 'JSON':
-            table = generate_table_result(
+    if output_type == 'QUIET':
+        return
+
+    if not output_type == 'JSON':
+        if action == 'list':
+            table = generate_list_table_result(
                 logger, results, output_type == 'TABLE-NO-HEADER')
-            if table:
-                print(table)
         else:
-            try:
-                _ = (entry for entry in results)
-                json_str = json.dumps(results)
-                if json_str:
-                    print(json_str)
-            except TypeError:
-                logger.debug('Output is not a JSON, and then cannot '
-                             'be printed with --output=JSON parameter.')
+            table = generate_table_results(results, output_type == 'TABLE-NO-HEADER')
+        if table:
+            print(table)
+    else:
+        try:
+            json_str = json.dumps(results)
+            if json_str:
+                print(json_str)
+        except TypeError:
+            logger.debug('Output is not JSON serializable, and then cannot '
+                         'be printed with --output=JSON parameter.')
 
 
 def main():
@@ -101,7 +118,7 @@ def main():
 
     results = client.execute()
 
-    handle_output(results, parsed_args.output)
+    handle_output(results, parsed_args.output, config.resolve('lexicon:action'))
 
 
 if __name__ == '__main__':

--- a/lexicon/cli.py
+++ b/lexicon/cli.py
@@ -16,10 +16,8 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 def generate_list_table_result(lexicon_logger, output=None, without_header=None):
     """Convert returned data from list actions into a nice table for command line usage"""
-    try:
-        isinstance(output, dict)
-    except TypeError:
-        lexicon_logger.debug('Command output is not a dict, and then cannot '
+    if not isinstance(output, list):
+        lexicon_logger.debug('Command output is not a list, and then cannot '
                              'be printed with --quiet parameter not enabled.')
         return None
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,12 +1,9 @@
+""" Ensure that stdout corresponds to the given reference output """
 from __future__ import absolute_import
-import importlib
 import json
 import logging
-import sys
-from types import ModuleType
 
 from lexicon import cli
-from lexicon.providers.base import Provider as BaseProvider
 
 
 logger = logging.getLogger(__name__)
@@ -16,8 +13,6 @@ data = [
     {'id': 'fake2-id', 'type': 'TXT', 'name': 'fake2.example.com',
         'content': 'fake2', 'ttl': 3600}
 ]
-
-# Ensure that stdout corresponds to the given reference output
 
 
 def assert_correct_output(capsys, expected_output_lines):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -33,7 +33,7 @@ def test_output_function_outputs_json_as_table(capsys):
         'fake2-id TXT  fake2.example.com fake2   3600',
     ]
 
-    cli.handle_output(data, 'TABLE')
+    cli.handle_output(data, 'TABLE', 'list')
     assert_correct_output(capsys, expected_output_lines)
 
 
@@ -43,12 +43,12 @@ def test_output_function_outputs_json_as_table_with_no_header(capsys):
         'fake2-id TXT fake2.example.com fake2 3600',
     ]
 
-    cli.handle_output(data, 'TABLE-NO-HEADER')
+    cli.handle_output(data, 'TABLE-NO-HEADER', 'list')
     assert_correct_output(capsys, expected_output_lines)
 
 
 def test_output_function_outputs_json_as_json_string(capsys):
-    cli.handle_output(data, 'JSON')
+    cli.handle_output(data, 'JSON', 'list')
 
     out, _ = capsys.readouterr()
     json_data = json.loads(out)
@@ -59,18 +59,18 @@ def test_output_function_outputs_json_as_json_string(capsys):
 def test_output_function_output_nothing_when_quiet(capsys):
     expected_output_lines = []
 
-    cli.handle_output(data, 'QUIET')
+    cli.handle_output(data, 'QUIET', 'list')
     assert_correct_output(capsys, expected_output_lines)
 
 
-def test_output_function_outputs_nothing_with_not_a_json_data(capsys):
+def test_output_function_outputs_nothing_with_not_a_json_serializable(capsys):
     expected_output_lines = []
 
-    cli.handle_output(True, 'TABLE')
+    cli.handle_output(object(), 'TABLE', 'list')
     assert_correct_output(capsys, expected_output_lines)
 
-    cli.handle_output(True, 'TABLE-NO-HEADER')
+    cli.handle_output(object(), 'TABLE-NO-HEADER', 'list')
     assert_correct_output(capsys, expected_output_lines)
 
-    cli.handle_output(True, 'JSON')
+    cli.handle_output(object(), 'JSON', 'list')
     assert_correct_output(capsys, expected_output_lines)


### PR DESCRIPTION
This PR improves how output is handled for non-list (eg. create) actions. Indeed, current output handling is designed only to tread correctly dict results generated by list actions. For other actions, output will depend on the nature of the object return by the action, and the chosen output type.

Question is more critical for TABLE output type, that is the default output:
* for boolean/integer results, as theses objects are not iterable, output will be silently suppressed, as with QUIET output option
* for string results, as theses objects are iterable but are not typical dicts returned during a list action, it will lead to an exception.

This issue can be avoid currently by setting the output to QUIET or JSON.

In this PR, non-list action results are handled correctly, by displaying them as expected with TABLE, TABLE-NO-HEADER and JSON. Also for JSON, all objects (not only iterable objects) can be displayed now, if they are JSON serializable. Non serializable objects will lead to no output, not an exception.

Fixes #272