### PR TITLE
Revert to a single execution of pylint, with fixed threshold

### DIFF
--- a/tests/pylint_quality_gate.py
+++ b/tests/pylint_quality_gate.py
@@ -1,64 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import shutil
-import tempfile
-import contextlib
-import stat
 import sys
-import subprocess
-from io import StringIO
 
 from pylint import lint
 
 
 REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GLOBAL_NOTE_THRESHOLD = 8.12
 
 
-@contextlib.contextmanager
-def capture():
-    oldout, olderr = sys.stdout, sys.stderr
-    try:
-        out = [StringIO(), StringIO()]
-        sys.stdout, sys.stderr = out
-        yield out
-    finally:
-        sys.stdout, sys.stderr = oldout, olderr
-        out[0] = out[0].getvalue()
-        out[1] = out[1].getvalue()
-
-
-def get_pylint_upstream_master_note():
-    """
-    Get the pylint global note of lexicon on upstream master branch
-    """
-    sys.stdout.write(
-        '===> Preparing a temporary local repository for upstream ... <===\n')
-    worktree_dir = tempfile.mkdtemp()
-
-    try:
-        sys.stdout.write('===> Executing pylint on upstream master '
-                         'to calculate pylint global note diff ... <===\n')
-
-        subprocess.check_output([
-            'git', 'clone', '--depth=1', 'https://github.com/AnalogJ/lexicon.git',
-            worktree_dir], stderr=subprocess.STDOUT)
-        subprocess.check_output(['pip', 'install', '-e', worktree_dir], stderr=subprocess.STDOUT)
-        with capture():
-            results = lint.Run([
-                os.path.join(worktree_dir, 'lexicon'), os.path.join(worktree_dir, 'tests'),
-                os.path.join(worktree_dir, 'tests', 'providers'), '--persistent=n'],
-                do_exit=False)
-
-        return results.linter.stats['global_note']
-    finally:
-        def del_rw(_, name, __):
-            os.chmod(name, stat.S_IWRITE)
-            os.remove(name)
-        shutil.rmtree(worktree_dir, onerror=del_rw)
-
-
-def quality_gate(stats, upstream_master_note):
+def quality_gate(stats):
     """
     Trigger various performance metrics on code quality.
     Raise if these metrics do not match expectations.
@@ -83,34 +35,31 @@ def quality_gate(stats, upstream_master_note):
     else:
         sys.stdout.write('2) OK. No "error" issues have been found.\n')
 
-    if stats['global_note'] < upstream_master_note:
-        sys.stderr.write('3) Failure: pylint global note is '
-                         'decreasing compared to master: {0} => {1}\n'
-                         .format(upstream_master_note, stats['global_note']))
+    if stats['global_note'] < GLOBAL_NOTE_THRESHOLD:
+        sys.stderr.write('3) Failure: pylint global note is below threshold: {0} < {1}\n'
+                         .format(stats['global_note'], GLOBAL_NOTE_THRESHOLD))
         quality_errors = True
     else:
-        sys.stdout.write('3) OK: pylint global is increasing or stable compared to master: '
-                         '{0} => {1}\n'.format(upstream_master_note, stats['global_note']))
+        sys.stdout.write('3) OK: pylint global note is beyond threshold: {0} >= {1}\n'
+                         .format(stats['global_note'], GLOBAL_NOTE_THRESHOLD))
 
     return 0 if not quality_errors else 1
 
 
 def main():
     """Main process"""
-    upstream_master_note = get_pylint_upstream_master_note()
-
     # Script is located two levels deep in the repository root (./tests/pylint_quality_gate.py)
     repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-    sys.stdout.write('===> Executing pylint on current branch ... <===\n')
-    subprocess.check_output(['pip', 'install', '-e', repo_dir], stderr=subprocess.STDOUT)
+    sys.stdout.write('===> Executing pylint ... <===\n')
     results = lint.Run([
-        os.path.join(repo_dir, 'lexicon'), os.path.join(repo_dir, 'tests'),
+        os.path.join(repo_dir, 'lexicon'),
+        os.path.join(repo_dir, 'tests'),
         os.path.join(repo_dir, 'tests', 'providers'), '--persistent=n'],
         do_exit=False)
 
     stats = results.linter.stats
-    sys.exit(quality_gate(stats, upstream_master_note))
+    sys.exit(quality_gate(stats))
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
 commands =
     python tests/pylint_quality_gate.py
 deps =
+    -r requirements.txt
     -r test-requirements.txt
     -r optional-requirements.txt
     pylint==2.1.1


### PR DESCRIPTION
Following #310, I implemented a quality gate. As there were a lot of pylint errors in current codebase, I try to make a "smarter" code quality continous improvment, by implementing a comparison between pylint results on master upstream and current branch, instead of a fixed threshold committed in the code.

This approach involved to make two pylint executions. First implementation was not working correctly, and has been "fixed" with #329.

I know observe that in a way or another, the two pylint executions are still coupled, and generate errors that should not appear: pylint seems to remember old signature of methods from master upstream, marking errors for signatures that evolve in current branch.

I have to admit that this approach is not a good one, and pylint is not made to make differential execution between two versions of the code.

So I revert to a simple pylint execution over current codebase, and testing against a fixed threshold. I will update it accordingly over the time.

Ultimately, and as fast as possible, I will correct all current pylint errors, to make a simpler code quality gate, that will certainly be: "do not add any pylint error".

@AnalogJ, as it is a simple operation, not touching functional code, but correcting errors during PR integrations, I will merge my own PR.