### PR TITLE
Added dehydrated HOOK_CHAIN support to example hook

### DIFF
--- a/examples/dehydrated.default.sh
+++ b/examples/dehydrated.default.sh
@@ -10,20 +10,35 @@ export PROVIDER_UPDATE_DELAY=${PROVIDER_UPDATE_DELAY:-"30"}
 export PROVIDER=${PROVIDER:-"cloudflare"}
 
 function deploy_challenge {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    local chain=($@)
+    for ((i=0; i < $#; i+=3)); do
+        local DOMAIN="${chain[i]}" TOKEN_FILENAME="${chain[i+1]}" TOKEN_VALUE="${chain[i+2]}"
 
-    echo "deploy_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
+        echo "deploy_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
-    
-    DELAY_COUNTDOWN=$PROVIDER_UPDATE_DELAY
-    while [ $DELAY_COUNTDOWN -gt 0 ]; do
-        echo -ne "$DELAY_COUNTDOWN\033[0K\r"
-        sleep 1
-        : $((DELAY_COUNTDOWN--))
+        if [ "${PROVIDER}" != "hetzner" ]; then
+            lexicon $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." \
+            --content="${TOKEN_VALUE}"
+        else
+            local PROPAGATED="yes"
+            if ((i < $# - 3)); then
+                local PROPAGATED="no"
+            fi
+            lexicon $PROVIDER create ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." \
+            --content="${TOKEN_VALUE}" --propagated="${PROPAGATED}"
+        fi
     done
 
-    # This hook is called once for every domain that needs to be
+    if [ "${PROVIDER}" != "hetzner" ]; then
+        local DELAY_COUNTDOWN=$PROVIDER_UPDATE_DELAY
+        while [ $DELAY_COUNTDOWN -gt 0 ]; do
+            echo -ne "${DELAY_COUNTDOWN}\033[0K\r"
+            sleep 1
+            : $((DELAY_COUNTDOWN--))
+        done
+    fi
+
+    # This hook is called once for every domain chain that needs to be
     # validated, including any alternative names you may have listed.
     #
     # Parameters:
@@ -42,15 +57,19 @@ function deploy_challenge {
 }
 
 function clean_challenge {
-    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"
+    local chain=($@)
+    for ((i=0; i < $#; i+=3)); do
+        local DOMAIN="${chain[i]}" TOKEN_FILENAME="${chain[i+1]}" TOKEN_VALUE="${chain[i+2]}"
 
-    echo "clean_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
+        echo "clean_challenge called: ${DOMAIN}, ${TOKEN_FILENAME}, ${TOKEN_VALUE}"
 
-    lexicon $PROVIDER delete ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." --content="${TOKEN_VALUE}"
+        lexicon $PROVIDER delete ${DOMAIN} TXT --name="_acme-challenge.${DOMAIN}." \
+        --content="${TOKEN_VALUE}"
+    done
 
-    # This hook is called after attempting to validate each domain,
-    # whether or not validation was successful. Here you can delete
-    # files or DNS records that are no longer needed.
+    # This hook is called after attempting to validate each domain
+    # chain, whether or not validation was successful. Here you
+    # can delete files or DNS records that are no longer needed.
     #
     # The parameters are the same as for deploy_challenge.
 }


### PR DESCRIPTION
This PR added dehydrated HOOK_CHAIN support to example hook. If there is any provider except Hetzner that implements an own propagation check, these providers should be handled, too.