### PR TITLE
Rename ProviderParser into provider_parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ and without spaces or special characters (eg. `cloudflare`)
 
 Your provider file should contain 2 things:
 
-- a `ProviderParser` which is used to add provider specific commandline arguments.
+- a `provider_parser` which is used to add provider specific commandline arguments.
 eg. If you define two cli arguments: `--auth-username` and `--auth-token`,
  those values will be available to your provider via `self._get_provider_option('auth_username')`
  or `self._get_provider_option('auth_token')` respectively

--- a/lexicon/parser.py
+++ b/lexicon/parser.py
@@ -58,7 +58,7 @@ def generate_cli_main_parser():
     for provider in providers:
         provider_module = importlib.import_module(
             'lexicon.providers.' + provider)
-        provider_parser = getattr(provider_module, 'ProviderParser')
+        provider_parser = getattr(provider_module, 'provider_parser')
 
         subparser = subparsers.add_parser(provider, help='{0} provider'.format(provider),
                                           parents=[generate_base_provider_parser()])

--- a/lexicon/providers/aurora.py
+++ b/lexicon/providers/aurora.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['auroradns.eu']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-api-key", help="specify API key for authentication")
     subparser.add_argument("--auth-secret-key",

--- a/lexicon/providers/auto.py
+++ b/lexicon/providers/auto.py
@@ -100,7 +100,7 @@ def _relevant_provider_for_domain(domain):
     return relevant_providers[0]
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = '''
         Provider 'auto' enables the Lexicon provider auto-discovery.
         Based on the nameservers declared for the given domain,
@@ -117,7 +117,7 @@ def ProviderParser(subparser):
     # Explore and load the arguments available for every provider into the 'auto' provider.
     for provider_name, provider_module in AVAILABLE_PROVIDERS.items():
         parser = argparse.ArgumentParser(add_help=False)
-        provider_module.ProviderParser(parser)
+        provider_module.provider_parser(parser)
 
         for action in parser._actions:
             action.option_strings = [re.sub(

--- a/lexicon/providers/cloudflare.py
+++ b/lexicon/providers/cloudflare.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['cloudflare.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Return the parser for this provider"""
     subparser.add_argument(
         "--auth-username", help="specify email address for authentication")

--- a/lexicon/providers/cloudns.py
+++ b/lexicon/providers/cloudns.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['cloudns.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     identity_group = subparser.add_mutually_exclusive_group()
     identity_group.add_argument(
         "--auth-id", help="specify user id for authentication")

--- a/lexicon/providers/cloudxns.py
+++ b/lexicon/providers/cloudxns.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['cloudxns.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate subparser for CloudXNS"""
     subparser.add_argument(
         "--auth-username", help="specify API-KEY for authentication")

--- a/lexicon/providers/conoha.py
+++ b/lexicon/providers/conoha.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['conoha.io']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-region", help="specify region. If empty, region `tyo1` will be used.")
     subparser.add_argument(

--- a/lexicon/providers/constellix.py
+++ b/lexicon/providers/constellix.py
@@ -34,7 +34,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['constellix.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify the API key username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/digitalocean.py
+++ b/lexicon/providers/digitalocean.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['digitalocean.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify token for authentication")
 

--- a/lexicon/providers/dnsimple.py
+++ b/lexicon/providers/dnsimple.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['dnsimple.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify api token for authentication")
     subparser.add_argument(

--- a/lexicon/providers/dnsmadeeasy.py
+++ b/lexicon/providers/dnsmadeeasy.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['dnsmadeeasy']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/dnspark.py
+++ b/lexicon/providers/dnspark.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['dnspark.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify api key for authentication")
     subparser.add_argument(

--- a/lexicon/providers/dnspod.py
+++ b/lexicon/providers/dnspod.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['dnsapi.cn']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify api id for authentication")
     subparser.add_argument(

--- a/lexicon/providers/easydns.py
+++ b/lexicon/providers/easydns.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['easydns.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/easyname.py
+++ b/lexicon/providers/easyname.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['easyname.eu']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = """A provider for Easyname DNS."""
     subparser.add_argument(
         '--auth-username',

--- a/lexicon/providers/exoscale.py
+++ b/lexicon/providers/exoscale.py
@@ -13,7 +13,7 @@ HOUR = 3600
 NAMESERVER_DOMAINS = ['exoscale.ch']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate subparser for exoscale"""
     subparser.add_argument(
         "--auth-key", help="specify API key for authentication"

--- a/lexicon/providers/gandi.py
+++ b/lexicon/providers/gandi.py
@@ -44,7 +44,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['gandi.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Specify arguments for Gandi Lexicon Provider."""
     subparser.add_argument('--auth-token', help="specify Gandi API key")
     subparser.add_argument(

--- a/lexicon/providers/gehirn.py
+++ b/lexicon/providers/gehirn.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['gehirn.jp']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Construct subparser for Gehirn"""
     subparser.add_argument(
         "--auth-token", help="specify access token for authentication")

--- a/lexicon/providers/glesys.py
+++ b/lexicon/providers/glesys.py
@@ -9,7 +9,7 @@ from lexicon.providers.base import Provider as BaseProvider
 NAMESERVER_DOMAINS = ['glesys.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate a subparser for Glesys"""
     subparser.add_argument(
         "--auth-username", help="specify username (CL12345)")

--- a/lexicon/providers/godaddy.py
+++ b/lexicon/providers/godaddy.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['godaddy.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate a subparser for Godaddy"""
     subparser.add_argument(
         '--auth-key', help='specify the key to access the API')

--- a/lexicon/providers/googleclouddns.py
+++ b/lexicon/providers/googleclouddns.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['googledomains.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate a subparser for Google Cloud DNS"""
     subparser.description = '''
         The Google Cloud DNS provider requires the JSON file which contains the service account info to connect to the API.

--- a/lexicon/providers/henet.py
+++ b/lexicon/providers/henet.py
@@ -21,7 +21,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['he.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = """A provider for Hurricane Electric DNS.
         NOTE: THIS DOES NOT WORK WITH 2-FACTOR AUTHENTICATION.
               YOU MUST DISABLE IT IF YOU'D LIKE TO USE THIS PROVIDER.

--- a/lexicon/providers/hetzner.py
+++ b/lexicon/providers/hetzner.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument('--auth-account',
                            help='specify type of Hetzner account: by default Hetzner Robot '
                            '(robot) or Hetzner konsoleH (konsoleh)')

--- a/lexicon/providers/internetbs.py
+++ b/lexicon/providers/internetbs.py
@@ -25,7 +25,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['topdns.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-key", help="specify API key for authentication")
     subparser.add_argument(

--- a/lexicon/providers/inwx.py
+++ b/lexicon/providers/inwx.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['inwx.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument("--auth-username",
                            help="specify username for authentication")
     subparser.add_argument("--auth-password",

--- a/lexicon/providers/linode.py
+++ b/lexicon/providers/linode.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['linode.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify api key for authentication")
 

--- a/lexicon/providers/linode4.py
+++ b/lexicon/providers/linode4.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['linode.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify api key for authentication")
 

--- a/lexicon/providers/localzone.py
+++ b/lexicon/providers/localzone.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--filename", help="specify location of zone master file")
 

--- a/lexicon/providers/luadns.py
+++ b/lexicon/providers/luadns.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['luadns.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify email address for authentication")
     subparser.add_argument(

--- a/lexicon/providers/memset.py
+++ b/lexicon/providers/memset.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['memset.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify API key for authentication")
 

--- a/lexicon/providers/namecheap.py
+++ b/lexicon/providers/namecheap.py
@@ -15,7 +15,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['namecheap.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         '--auth-token',
         help='specify api token for authentication'

--- a/lexicon/providers/namesilo.py
+++ b/lexicon/providers/namesilo.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['namesilo.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify key for authentication")
 

--- a/lexicon/providers/nfsn.py
+++ b/lexicon/providers/nfsn.py
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['nearlyfreespeech.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Generate subparser for nfsn"""
     subparser.add_argument(
         "--auth-username", help="specify username used to authenticate")

--- a/lexicon/providers/nsone.py
+++ b/lexicon/providers/nsone.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['nsone.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify token for authentication")
 

--- a/lexicon/providers/onapp.py
+++ b/lexicon/providers/onapp.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = '''
         The OnApp provider requires your OnApp account\'s email address and
         API token, which can be found on your /profile page on the Control Panel interface.

--- a/lexicon/providers/online.py
+++ b/lexicon/providers/online.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['online.net']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument("--auth-token", help="specify private api token")
 
 

--- a/lexicon/providers/ovh.py
+++ b/lexicon/providers/ovh.py
@@ -23,7 +23,7 @@ ENDPOINTS = {
 NAMESERVER_DOMAINS = ['ovh.net', 'anycast.me']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = '''
         OVH Provider requires a token with full rights on /domain/*.
         It can be generated for your OVH account on the following URL:

--- a/lexicon/providers/plesk.py
+++ b/lexicon/providers/plesk.py
@@ -26,7 +26,7 @@ plesk_url_suffix = "/enterprise/control/agent.php"
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/pointhq.py
+++ b/lexicon/providers/pointhq.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['pointhq.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify email address for authentication")
     subparser.add_argument(

--- a/lexicon/providers/powerdns.py
+++ b/lexicon/providers/powerdns.py
@@ -33,7 +33,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify token for authentication")
     subparser.add_argument("--pdns-server", help="URI for PowerDNS server")

--- a/lexicon/providers/rackspace.py
+++ b/lexicon/providers/rackspace.py
@@ -23,7 +23,7 @@ def _async_request_completed(payload):
     return False
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-account", help="specify account number for authentication")
     subparser.add_argument(

--- a/lexicon/providers/rage4.py
+++ b/lexicon/providers/rage4.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['rage4.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify email address for authentication")
     subparser.add_argument(

--- a/lexicon/providers/route53.py
+++ b/lexicon/providers/route53.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = [re.compile(r'^awsdns-\d+\.\w+$')]
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     """Specify arguments for AWS Route 53 Lexicon Provider."""
     subparser.add_argument("--auth-access-key",
                            help="specify ACCESS_KEY for authentication")

--- a/lexicon/providers/sakuracloud.py
+++ b/lexicon/providers/sakuracloud.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['sakura.ne.jp']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify access token for authentication")
     subparser.add_argument(

--- a/lexicon/providers/softlayer.py
+++ b/lexicon/providers/softlayer.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['softlayer.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/subreg.py
+++ b/lexicon/providers/subreg.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['subreg.cz']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/transip.py
+++ b/lexicon/providers/transip.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = []
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-username", help="specify username for authentication")
     subparser.add_argument(

--- a/lexicon/providers/vultr.py
+++ b/lexicon/providers/vultr.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['vultr.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify token for authentication")
 

--- a/lexicon/providers/yandex.py
+++ b/lexicon/providers/yandex.py
@@ -15,7 +15,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['yandex.com']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token",
         help="specify PDD token (https://tech.yandex.com/domain/doc/concepts/access-docpage/)")

--- a/lexicon/providers/zeit.py
+++ b/lexicon/providers/zeit.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 NAMESERVER_DOMAINS = ['zeit.world']
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.description = '''
         Zeit Provider requires a token to access its API.
         You can generate one for your account on the following URL:

--- a/lexicon/providers/zonomi.py
+++ b/lexicon/providers/zonomi.py
@@ -34,7 +34,7 @@ NAMESERVER_DOMAINS = ['zonomi.com']
 #   type and content.
 
 
-def ProviderParser(subparser):
+def provider_parser(subparser):
     subparser.add_argument(
         "--auth-token", help="specify token for authentication")
     subparser.add_argument("--auth-entrypoint", help="use Zonomi or Rimuhosting API", choices=[

--- a/tests/providers/integration_tests.py
+++ b/tests/providers/integration_tests.py
@@ -102,12 +102,12 @@ class IntegrationTests(object):
             'lexicon.providers.{0}'.format(
                 self.provider_name))
 
-        assert hasattr(module, 'ProviderParser')
+        assert hasattr(module, 'provider_parser')
         assert hasattr(module, 'Provider')
         if self.provider_name != 'auto':
             assert hasattr(module, 'NAMESERVER_DOMAINS')
 
-        assert callable(module.ProviderParser)
+        assert callable(module.provider_parser)
         assert callable(module.Provider)
         if self.provider_name != 'auto':
             assert isinstance(module.NAMESERVER_DOMAINS, list)


### PR DESCRIPTION
As `ProviderParser` is a function, so it should be named `provider_parser`.

This PR modifies the name of this function in all provider modules. I did not put retro-compatibility logic on `ProviderParser` attribute name in the provider modules, because this function is for internal use, to build Lexicon CLI. In particulier Certbot uses only the `Provider` class, and nothing else.

But if it is a problem, I can build a retro-compatible logic. 