### PR TITLE
Make config directory to search configurable with --config-dir

### DIFF
--- a/lexicon/cli.py
+++ b/lexicon/cli.py
@@ -108,9 +108,9 @@ def main():
     # In the CLI context, will get configuration interactively:
     #   * from the command line
     #   * from the environment variables
-    #   * from lexicon configuration files in working directory
+    #   * from lexicon configuration files found in given --config-dir (default is current dir)
     config = ConfigResolver()
-    config.with_args(parsed_args).with_env().with_config_dir(os.getcwd())
+    config.with_args(parsed_args).with_env().with_config_dir(parsed_args.config_dir)
 
     client = Client(config)
 

--- a/lexicon/parser.py
+++ b/lexicon/parser.py
@@ -2,6 +2,7 @@
 import argparse
 import importlib
 import pkgutil
+import os
 
 import pkg_resources
 from lexicon import providers as providers_package
@@ -51,6 +52,10 @@ def generate_cli_main_parser():
     parser.add_argument('--version', help='show the current version of lexicon',
                         action='version', version='%(prog)s {0}'.format(version))
     parser.add_argument('--delegated', help='specify the delegated domain')
+    parser.add_argument('--config-dir', default=os.getcwd(),
+                        help='specify the directory where to search lexicon.yml and '
+                             'lexicon_[provider].yml configuration files '
+                             '(default: current directory).')
     subparsers = parser.add_subparsers(
         dest='provider_name', help='specify the DNS provider to use')
     subparsers.required = True


### PR DESCRIPTION
Well, the title is self-explanatory ^^

This PR add the `--config-dir` optional parameter to the Lexicon main parser, in order to let a user select its own directory where to search the configuration files. If not set, current directory is used, like before.