### PR TITLE
Socket can also throw IOError

### DIFF
--- a/lexicon/tests/providers/test_auto.py
+++ b/lexicon/tests/providers/test_auto.py
@@ -28,7 +28,7 @@ def _there_is_no_network():
     try:
         socket.create_connection(("www.google.com", 80))
         return False
-    except OSError:
+    except (OSError, IOError):
         pass
     return True
 


### PR DESCRIPTION
Catch for IOError if there is no network too.

Otherwise you get:
`E   IOError: [Errno socket error] [Errno -3] Temporary failure in name resolution`
