### PR TITLE
Allow specifiying Gandi sharing ID

### DIFF
--- a/lexicon/providers/gandi.py
+++ b/lexicon/providers/gandi.py
@@ -50,6 +50,10 @@ def provider_parser(subparser):
     subparser.add_argument(
         '--api-protocol',
         help="(optional) specify Gandi API protocol to use: rpc (default) or rest")
+    subparser.add_argument(
+        '--sharing-id',
+        help="Gandi sharing ID "
+             "(required if your domain is in an organization and using REST protocol)")
 
 
 class Provider(BaseProvider):
@@ -63,6 +67,7 @@ class Provider(BaseProvider):
         super(Provider, self).__init__(config)
         self.default_ttl = 3600
         self.protocol = self._get_provider_option('api_protocol') or 'rpc'
+        self.sharing_id = self._get_provider_option('sharing_id')
 
         if self.protocol != 'rpc' and self.protocol != 'rest':
             raise ValueError(
@@ -241,6 +246,8 @@ class Provider(BaseProvider):
             data = {}
         if query_params is None:
             query_params = {}
+        if self.sharing_id is not None:
+            query_params['sharing_id'] = self.sharing_id
         default_headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/lexicon/tests/providers/test_gandi.py
+++ b/lexicon/tests/providers/test_gandi.py
@@ -26,5 +26,8 @@ class GandiRESTProviderTests(TestCase, IntegrationTests):
     def _filter_headers(self):
         return ['X-Api-Key']
 
+    def _filter_query_parameters(self):
+        return ['sharing_id']
+
     def _test_parameters_overrides(self):
         return {'api_protocol': 'rest'}


### PR DESCRIPTION
If your domain is in an organization within Gandi LiveDNS, but your API
token is a personal one, then you must specify the Sharing ID of the
organization which the domain you wish to modify is within.