### PR TITLE
Add netcup provider

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,7 @@ lexicon/providers/luadns.py         @analogj
 lexicon/providers/memset.py         @tnwhitwell
 lexicon/providers/namecheap.py      @pschmitt @rbelnap
 lexicon/providers/namesilo.py       @analogj
+lexicon/providers/netcup.py         @coldfix
 lexicon/providers/nfsn.py           @tersers
 lexicon/providers/nsone.py          @init-js @trinopoty
 lexicon/providers/onapp.py          @alexzorin

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The current supported providers are:
 - Memset ([docs](https://www.memset.com/apidocs/methods_dns.html))
 - Namecheap ([docs](https://www.namecheap.com/support/api/methods.aspx))
 - Namesilo ([docs](https://www.namesilo.com/api_reference.php))
+- Netcup ([docs](https://ccp.netcup.net/run/webservice/servers/endpoint.php))
 - NFSN (NearlyFreeSpeech)
 - NS1 ([docs](https://ns1.com/api/))
 - OnApp ([docs](https://docs.onapp.com/display/55API/OnApp+5.5+API+Guide))

--- a/lexicon/providers/netcup.py
+++ b/lexicon/providers/netcup.py
@@ -1,0 +1,178 @@
+"""Module provider for Netcup"""
+from __future__ import absolute_import
+import json
+import logging
+
+import requests
+from lexicon.providers.base import Provider as BaseProvider
+
+
+LOGGER = logging.getLogger(__name__)
+
+NAMESERVER_DOMAINS = ['netcup.de']
+
+
+def provider_parser(subparser):
+    """Configure provider parser for Netcup"""
+    subparser.add_argument(
+        "--auth-customer-id", help="specify customer number for authentication")
+    subparser.add_argument(
+        "--auth-api-key", help="specify API key for authentication")
+    subparser.add_argument(
+        "--auth-api-password", help="specify API password for authentication")
+
+
+class Provider(BaseProvider):
+    """Provider class for Netcup"""
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        self.domain_id = 0
+        self.zone_ttl = None
+        self.api_session_id = None
+        self.api_endpoint = (
+            self._get_provider_option('api_endpoint') or
+            'https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON')
+
+    # lexicon.provider.Provider overrides:
+
+    def _authenticate(self):
+        """Authenticate with netcup server. Must be called first."""
+        login_info = self._apicall('login')
+        self.api_session_id = login_info['apisessionid']
+        if not self.api_session_id:
+            raise Exception('Login failed')
+        # query ttl and verify access to self.domain:
+        zone_info = self._apicall('infoDnsZone', domainname=self.domain)
+        self.zone_ttl = zone_info['ttl']
+
+    def _create_record(self, rtype, name, content):
+        """Create record. If it already exists, do nothing."""
+        if not self._list_records(rtype, name, content):
+            self._update_records([{}], {
+                'type': rtype,
+                'hostname': self._relative_name(name),
+                'destination': content,
+                'priority': self._get_lexicon_option('priority'),
+            })
+        LOGGER.debug('create_record: %s', True)
+        return True
+
+    def _list_records(self, rtype=None, name=None, content=None):
+        """List all records. Return an empty list if no records found.
+        ``rtype``, ``name`` and ``content`` are used to filter records."""
+        records = [
+            {
+                'id': record['id'],
+                'type': record['type'],
+                'name': self._full_name(record['hostname']),
+                'content': record['destination'],
+                'priority': record['priority'],
+                'ttl': self.zone_ttl,
+            }
+            for record in self._raw_records(None, rtype, name, content)
+        ]
+        LOGGER.debug('list_records: %s', records)
+        return records
+
+    def _update_record(self, identifier, rtype=None, name=None, content=None):
+        """Create or update a record."""
+        records = self._raw_records(identifier, rtype, name, content)
+        self._update_records(records, {
+            'type': rtype,
+            'hostname': self._relative_name(name),
+            'destination': content,
+            'priority': self._get_lexicon_option('priority'),
+        })
+        LOGGER.debug('update_record: %s', True)
+        return True
+
+    def _delete_record(self, identifier=None, rtype=None, name=None, content=None):
+        """Delete an existing record. If record does not exist, do nothing."""
+        records = self._raw_records(identifier, rtype, name, content)
+        LOGGER.debug('delete_records: %s', [rec['id'] for rec in records])
+        self._update_records(records, {
+            'deleterecord': True,
+            'type': rtype,
+            'hostname': name,
+            'destination': content,
+        })
+        LOGGER.debug('delete_record: %s', True)
+        return True
+
+    # Helpers
+
+    def _raw_records(self, identifier=None, rtype=None, name=None, content=None):
+        """Return list of record dicts in the netcup API convention."""
+        record_fields = {
+            'id': identifier,
+            'type': rtype,
+            'hostname': name and self._relative_name(name),
+            'destination': content,
+        }
+        # type/hostname/destination of the dnsrecord type are mandatory (even
+        # when deleting), and must be queried if not all were specified:
+        if all(record_fields.values()):
+            return [record_fields]
+        data = self._apicall('infoDnsRecords', domainname=self.domain)
+        records = data.get('dnsrecords', [])
+        return [
+            record for record in records
+            if all(record[k] == v for k, v in record_fields.items() if v)
+        ]
+
+    def _update_records(self, records, data):
+        """Insert or update a list of DNS records, specified in the netcup API
+        convention.
+
+        The fields ``hostname``, ``type``, and ``destination`` are mandatory
+        and must be provided either in the record dict or through ``data``!
+        """
+        data = {k: v for k, v in data.items() if v}
+        records = [dict(record, **data) for record in records]
+        return self._apicall(
+            'updateDnsRecords',
+            domainname=self.domain,
+            dnsrecordset={'dnsrecords': records},
+        ).get('dnsrecords', [])
+
+    def _apicall(self, method, **params):
+        """Call an API method and return response data. For more info, see:
+        https://ccp.netcup.net/run/webservice/servers/endpoint"""
+        LOGGER.debug('%s(%r)', method, params)
+        auth = {
+            'customernumber': self._get_provider_option('auth_customer_id'),
+            'apikey': self._get_provider_option('auth_api_key'),
+        }
+        if method == 'login':
+            auth['apipassword'] = self._get_provider_option('auth_api_password')
+        else:
+            auth['apisessionid'] = self.api_session_id
+        if not all(auth.values()):
+            raise Exception('No valid authentication mechanism found')
+        data = self._request('POST', url='', data={
+            'action': method,
+            'param': dict(params, **auth),
+        })
+        if data['status'] != 'success':
+            raise Exception("{} ({})".format(
+                data['longmessage'], data['statuscode']))
+        return data.get('responsedata', {})
+
+    def _request(self, action='GET', url='/', data=None, query_params=None):
+        """Perform network request to configured JSON endpoint."""
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        default_headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+        response = requests.request(
+            action,
+            self.api_endpoint + url,
+            data=json.dumps(data),
+            params=query_params,
+            headers=default_headers)
+        response.raise_for_status()
+        return response.json()

--- a/lexicon/tests/providers/test_netcup.py
+++ b/lexicon/tests/providers/test_netcup.py
@@ -1,0 +1,25 @@
+"""Integration tests for netcup"""
+from unittest import TestCase
+import pytest
+from lexicon.tests.providers.integration_tests import IntegrationTests
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from define_tests.TheTests
+class NetcupProviderTests(TestCase, IntegrationTests):
+    """TestCase for netcup."""
+    provider_name = 'netcup'
+    domain = 'coldfix.de'
+
+    def _filter_post_data_parameters(self):
+        # actually only param[customerid, apikey, apipassword, apisessionid],
+        # but I don't think this method allows filtering nested keys...
+        return ['param']
+
+    def _test_parameters_overrides(self):
+        return {'api_endpoint': 'https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON'}
+
+    @pytest.mark.skip(reason="TTL can not be set via netcup API")
+    def test_provider_when_calling_list_records_after_setting_ttl(self):
+        pass

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"VVT21k24FyQT0A2b2x11IsUM9M0j","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MjE3NXBjOTM0OFA2cHZBbW9IYVRqR2JyU2ZCUm1RSTV4ZzU3Zj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:26 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:26 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"NkBLx49U0TTyjd162ny32cTEG41b","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042071","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:26 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:26 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"HwG4jQj9mEM4MOXb125WxYRMJ012","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NWo5MjcxNms0ODNCNHZBbW9IYVRqR2JyU2ZCUm1RSTU3NDMyOH"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:27 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:27 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['241']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"x9YDWnc1YON522yQMlFld01zMw14","clientrequestid":"","action":"infoDnsZone","status":"error","statuscode":5031,"shortmessage":"Getting
+        DNS zone failed","longmessage":"Can not get DNS records for zone.  Domain
+        not found.","responsedata":""}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:27 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:27 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['257']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"5yj14jV61VAk9xMZEzNF0e0o221M","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"azQ3MTVoOTgzVDI2aHZBbW9IYVRqR2JyU2ZCUm1RSTU5MTYyNF"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:28 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:28 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"7NnIlT01N0Ex2B4jxONy1DRI3249","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042071","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:28 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:28 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"GOKj09WTT1B421FMk42JTu8HlQa0","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:29 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:29 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['502']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['332']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"6912XjhjA1YUyDkNFMMQ940n51N2","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:30 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:30 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['661']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"TxeAUwGUc01I01902F12yROj5xcR","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"Mnl2ODQzMTU5bTc2NnZBbW9IYVRqR2JyU2ZCUm1RSTUxMjUzdD"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:30 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:30 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"12IUTl2ckUZw59T1ExTNx0W1My5Q","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042072","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:31 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:31 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"0Rx0c52I1Z9LMSV25y25Myj10UU2","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:31 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:31 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['634']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['338']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"MeR1xA12n5D9EyT5Vk3x0Ws2Tz5M","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:33 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:33 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['799']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"eW5THYEVMy0Dj29FTym1M42Ik01T","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MzQ3NncyazU5ODFzM3ZBbW9IYVRqR2JyU2ZCUm1RSTU3VTI5NT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:33 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:33 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Y11VTTzT9y0221E6mAczj45MMh55","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042073","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:34 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:33 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"R2TM2A90VyK6l2JjZNU1FG1xG53N","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:34 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:34 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['772']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['350']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"23b09DRM2kAz1V5y2yIFWA71ZN4c","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:35 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:35 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['949']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"QO8V1XGJj5EWMWTD1F4229N015zZ","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NjkyNTczMXlNUzg0NHZBbW9IYVRqR2JyU2ZCUm1RSTVxM0s1OD"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2101VRw2QOycF0VZ5jZEQI5z9915","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042074","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2IanNj9TxA1j2ZA10J20j6yWz12O","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:36 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['922']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['350']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"MjlI0Vj1F1x22EWYnbwbj19lN6Fx","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:38 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:38 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1099']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"22y261D0zlM1ScNjR9Im2bxFhxA1","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MXI5SDgzNzU0YTI2MnZBbW9IYVRqR2JyU2ZCUm1RSTU1MVo5Mz"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:38 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:38 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"XMMBwk1DzUyl2I6TTVU92Ec0231N","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042075","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:39 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:39 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Z26z0QMDzY2E4Tdjo1E90wdWy115","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:39 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:39 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1072']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['350']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"M25MI1w6E01VQm9EWkG5oVy2Z1Tt","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:40 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:40 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1249']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"x05lYE962eDMMUT1R6MhpcDWT2J1","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NDh6NzI1NkczOVMxMXZBbW9IYVRqR2JyU2ZCUm1RSTU0N3c2MX"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:41 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:41 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"4TO5kMD701y2TJI36g9E1zWA2dT2","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042076","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:41 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:41 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"xa80136ymNOdpNDQ2gT129EVDWdT","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:42 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:42 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1222']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['362']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"hxN1MxDGmE1j26059tR9mbjdeJ2I","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:43 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:43 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1411']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Mz19bxIVU270l01O1MZQi3ATa2zD","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:44 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:43 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1384']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['362']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"91jlMiI0M7121pMX1w0jMF2hQTUF","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:45 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:45 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1573']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,177 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"22XjjZj97MR5R1J0Mc1FJN32hVVK","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NWNUNzM4NDYyMTlTNnZBbW9IYVRqR2JyU2ZCUm1RSTUyNjlFQT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:45 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:45 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"0z9U72dyk1d3A1jkM3jNxzlj2B0S","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042078","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:46 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:46 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"lZDVMdy2R3j0kTwNM91M712MNMn4","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:46 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:46 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1546']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['350']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"0M9tV5Z1z2kMDnYZN2J7110x3MYY","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:47 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:47 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1723']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"6FE7R920Mzj31GMNZ15YM2OXUTVm","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:48 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:48 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"J2z2kUzIyx173Nw1c9rE7OME3lN0","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:48 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:48 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"EEn2M11Ixa2WW7jhz8T5ZkF9W0je","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"OTUyMTc2ODRxM2pzN3ZBbW9IYVRqR2JyU2ZCUm1RSTU3UTgyNj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"92kUMxN2DU9k1Usxam0EdlD57z1y","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042079","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"tg282EO119y0DbsOD0x1MDmwTdJM","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:49 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2Byw12M19jmD1cjFUNM400dc28OQ","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758168","hostname":"delete.testfilt","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:51 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:51 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1868']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1J8U2TU2jEOxlMU10T2nR94TAyZo","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758168","hostname":"delete.testfilt","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:51 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:51 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1841']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['422']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"8132WB09V2TDgMNk15rI3TxZMkNM","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1723']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"N52ykO521W81DQxV4EFFsODNW0M9","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"lMM533Zb9rJI11DZUTN2Ox18D0M2","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"ODUyNzZxczE0UTM5MXZBbW9IYVRqR2JyU2ZCUm1RSTU1N2MzMj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:52 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1yS2UBzRJ1TcwO0xYMd6zVTU9M82","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042081","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:53 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:53 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"N29rMQF122N1aR5Q1z0847TIM3TB","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:53 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:53 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"OgDZ8x9F2ZhIQ8j2x0tTAjyM1zT1","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758169","hostname":"delete.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1868']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"O5F2Ej1oZj8hMjd9I1ex5Hn2Ac90","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758169","hostname":"delete.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1841']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['434']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"251T0Fa1pMIzDWVISJ2MI950b9o2","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:55 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1723']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"xzMFJC2W19TV1OF1dkEDM0o9yE2L","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:56 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:56 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"yOT2wOl92nMw92T1MY0U1VDlJXMj","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"cTlVNzE4MzY1MjRQVXZBbW9IYVRqR2JyU2ZCUm1RSTU1bjQyMT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:56 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:56 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"NIM532Yxnj192zBdkz2F01RXlMM9","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042083","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:57 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:57 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"c0gHkaxHlM49u2Q90M1DS41xJ2Ej","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:57 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:57 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"YYM1NTye02AUJ21195xu9DTTZOTm","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758170","hostname":"delete.testfull","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:58 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:58 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1868']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"W2I6JzMIlMCD49XTVd029GOcT115","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758170","hostname":"delete.testfull","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1841']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['433']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"X6XTyXZxA19150Q2Ncz9OzMII7Z2","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1723']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"TMT02J9y9geMTd508JZ1mD1gwUy2","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:37:59 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,236 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"y0IM599Z11jU2SYFoFRNUM9GUlD2","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NjRTSDkzRTg1MjE3U3ZBbW9IYVRqR2JyU2ZCUm1RSTU4YTc0Nj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:00 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:00 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"DIYzVkmO0MxF0ZTwV03M1Ejl92z1","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042085","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:00 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:00 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"xT0H2M1QMH1My1XY3Me9R54UMZM0","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:01 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:01 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['343']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"003UG3GM9MwxloJy12V1o0MU43wx","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758171","hostname":"delete.testid","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:02 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:02 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1866']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1k0x5M9l1d1REN11UxD42n3W1zcM","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758171","hostname":"delete.testid","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:03 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:03 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1839']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"z12OT5Z330JIOMd9TTzxT3j2JOE1","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758171","hostname":"delete.testid","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:03 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:03 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1839']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['420']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"EOzlTMy3RMbeYUG22D015mx9nV91","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1723']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"V0kU23Mb113MHxy0HTMMzk9zg3TV","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,266 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"311yzTEIZ2j9E0TE5z2VMcy01R3B","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"N01kMzlnNDU4MjE2OXZBbW9IYVRqR2JyU2ZCUm1RSTUydjU0aD"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:04 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"R31zUN325BDFFXOFj11aOzM50So9","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042087","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:05 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:05 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"TMx2zW7e3MmcMz53d91AVWIpr01T","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:05 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:05 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1696']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['364']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"hz4aU3M1hR830Es5GOxj20MI19Vz","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758172","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:07 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:06 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1887']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"MRxBs9UOUljk34L5T19UMz3o1W02","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758172","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:07 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:07 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1860']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['364']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1F4NT1bLjBa0MiN925AX0n0z3Q1M","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758172","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:08 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:08 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2051']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2TMFS6wQYc111M5GT0I2xNL4G913","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758172","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2024']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['453']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"0HMy1195FY1wTylM4SEE3Ub2dMN2","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1887']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2jz4MQ9Md31KF1BMW3JMTWDj150E","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:09 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1860']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,266 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Ah0QzZV44M14DjUM3VBNEynFl921","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"a1cyN0I0MTk4NjM1N3ZBbW9IYVRqR2JyU2ZCUm1RSTUzajU2OT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:10 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:10 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"U6zNl51JFaja9z0MMT2MFO0M31F4","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042090","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:10 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:10 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"M46Z1Zh90juI0w1QzFVWNM23Ek1T","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:11 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:11 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1860']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['362']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Jl0k02N3ZGTaz17tF3NMjc941MzN","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758174","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:12 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:12 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2049']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"N410VjOb19Ek2yy0DBjByj38aJzE","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758174","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:12 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:12 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2022']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['362']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2lIVG9M4wSA39MFy1T1cxMz5cRk0","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758174","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758175","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:14 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:14 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2211']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"9ka2adhyM51zD10TTU0D3EoOGVlA","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758174","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758175","hostname":"_acme-challenge.deleterecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:14 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:14 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2184']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['638']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"09inNEz11UFMgxMzwJ2gc5F3RX51","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1887']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"VDc2jLMwF510I4G315R9EMUD2TZ2","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1860']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"z9WU2j5JZ3jz4AHSl1MN1gMx3j0S","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MzIxZng4Rjc1OTQ2NXZBbW9IYVRqR2JyU2ZCUm1RSTVKMjQxNT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:15 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"JR30z1121K52T9MMMMTkMT4AN50U","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042093","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:16 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:16 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"09WXzMD2NEyQjVl5R3TMV11Mo1A5","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:16 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:16 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['1860']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['360']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"XGM0I2D9MuY1J5RVORZyzT1z3F6M","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:17 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:17 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2047']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"y2OT1KR5973D21MtVoF30WScMFN5","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:18 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:18 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2020']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['360']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Dl2Y453TJMGC1M8091RMTHz5FMt4","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:19 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:19 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2207']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"j19913OZS02zxR0Uzix2M5VpkUWW","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2180']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"WD2xAy132EV60EMV5MME9z1IN230","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MzQ2RFc3NTk4RzIxNHZBbW9IYVRqR2JyU2ZCUm1RSTU1bWc0Mz"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"6M1102N1dR0METwJMMgW9VWN3l3x","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042095","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:20 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"nzzzD0E193612MxkN2IZlYQwo1Nj","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:21 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:21 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2180']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"mpOT3lnH1N1z0h1wMERMX0T9J236","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:22 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:22 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2352']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"XMM65yjRV13nw6EQZR01kMz92ZM4","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2325']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"xb2ZA1MxlX6N3TV15SQ9l51FE0Nj","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"UDN5NTc5MTQ2MlQ4OXZBbW9IYVRqR2JyU2ZCUm1RSTVTMTdDND"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"NEZDx6U2kx0c1OI6903NDJNj1McZ","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042096","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:23 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"T23RT0cNNZ1md9MMSo6GwJ4jCY71","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:24 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:24 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2325']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['345']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"SHMzzNN8FyQnY2El3w1c01OV496M","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:25 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:25 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2497']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2T0JzE119V3zc2hM9SO6GOOTjV5B","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2470']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"M7swNxF11322mMN20UR4zRJV5019","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MjYzNFNmODE5NzV2OHZBbW9IYVRqR2JyU2ZCUm1RSTUzOHQxND"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"UNR1j19jeMz13kRgFWMyD07Y3Mx2","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042097","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:26 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"5lFm1VA72cRuD3WN0MMT19h2MzhF","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:27 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:27 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2470']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"lGU3xjC91lDdMF027M2z3N1MZUzd","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"Zzc0MTg5eTUyM0E2OXZBbW9IYVRqR2JyU2ZCUm1RSTU0Zzk4NT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:27 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:27 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"NQMMxIRMzH0U94uu5z2ZF1Qp7131","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042097","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:28 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:28 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"m3051KYEyUM1703M9tTW2j1SFlTm","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:28 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:28 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2470']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['341']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"15F10Y32A7SO2x9D6yZYdDZzT0NM","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:29 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:29 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2638']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"o2RNzmYDz19N3B15B73VN0M1ZmF7","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:30 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:30 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2611']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2mc8cg3NmT0M1UzTxg7BOa9m013M","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MzU2ODQ3azkyTTFWN3ZBbW9IYVRqR2JyU2ZCUm1RSTU0MTUzOG"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:30 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:30 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"4O0x3Xko71wQMN9Nxz9112VMH0mR","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042098","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"UFb1wz9Vd0281MEzTwI3lgT0jNwj","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2611']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"y5NwTU9M8JZ31bj1TMkxg2E01jdT","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MzdnNUUyODQxNjl4RXZBbW9IYVRqR2JyU2ZCUm1RSTVCNzM5MT"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:31 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"Mjtk9lx3Bho1NykJM281jQ1c2T50","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042098","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:32 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:32 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"9z8xxM1YDxM5W123AM3kWO0cO3FT","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:32 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:32 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2611']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['339']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"3Nj2U1TZ1MSZl8E1G4kx9TEE40w3","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"orig.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2777']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"p01l5MTx03U5ZcQZV80OI1lzD259","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"orig.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2750']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['360']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"4lM1x3xT1k6TMB29M018TzYZzXcg","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:34 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2780']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"3cjO01MDXyU328MQZ7nOx10J93ZE","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NjJ1NTh3NzQzMUI5NHZBbW9IYVRqR2JyU2ZCUm1RSTU2NTM3Mj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:35 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:35 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1jM21x1Y9Jk8TdJEl3Y2TW34Q0T8","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042100","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:35 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:35 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"V4W9MNh21N3Od0VkVL1O8UT0j9MF","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:36 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:35 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2753']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['348']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"NEOxz0B0Wzd5Bxi992aTo1QM13VO","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:37 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:37 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2928']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1M2ZU51XV4jM3MUwya9RBs01Xk9Y","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:37 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:37 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2901']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['266']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"STMOwj1Ed3z90U2gg5wFxd191M2j","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2928']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"O3DzVFMwE01c21TzalMl99M13aEF","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"NTM2N3M4OWoxNGQyMnZBbW9IYVRqR2JyU2ZCUm1RSTUxNUY3Mj"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"2DEO30D5N5M1V94WlNzNtTB9ukF1","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042101","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:38 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"nMR1MTTlYG1ZV3R59n1Q5M09ET2V","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:39 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:39 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['2901']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['343']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"9V3Mkx16N9n1FyjFYONNAyjW02TY","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"orig.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:40 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:40 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3071']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"3M950z57I3HZ1x12IaFlzEOzNF92","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"orig.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3044']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['364']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"M93GG1jbJ10Vx09tmEV4W2M4kZD8","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"updated.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3074']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/netcup/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,178 @@
+interactions:
+- request:
+    body: '{"action": "login"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['190']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"N9xE4IT31TT0OkNhZ9MC9O01MZl2","clientrequestid":"","action":"login","status":"success","statuscode":2000,"shortmessage":"Login
+        successful","longmessage":"Session has been created successful.","responsedata":{"apisessionid":"MjQ1NnR1NzM5djE4OXZBbW9IYVRqR2JyU2ZCUm1RSTUxMjVmMz"}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:41 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['297']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsZone"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['225']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"x1VE0F9RjC1Md0IWTOM04DBaOTI2","clientrequestid":"","action":"infoDnsZone","status":"success","statuscode":2000,"shortmessage":"DNS
+        zone found","longmessage":"DNS zone was found.","responsedata":{"name":"coldfix.de","ttl":"86400","serial":"2019042103","refresh":"28800","retry":"7200","expire":"1209600","dnssecstatus":false}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:42 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:42 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['345']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"1wU40y0wRTMxVT2xj1A1cUzM9YlR","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"updated.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:42 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:42 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3047']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['343']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"4TlBk1EDz2BER01J09nyd2YzNjSD","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758184","hostname":"orig.testfull","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"updated.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3217']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "infoDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['228']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"4AJDV32oyW11wN9WM0UZMdzTDlT0","clientrequestid":"","action":"infoDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records found","longmessage":"DNS Records for this zone were found.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758184","hostname":"orig.testfull","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"updated.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3190']
+    status: {code: 200, message: OK}
+- request:
+    body: '{"action": "updateDnsRecords"}'
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['364']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.21.0]
+    method: POST
+    uri: https://ccp.netcup.net/run/webservice/servers/endpoint.php?JSON
+  response:
+    body: {string: '{"serverrequestid":"9W4zF41Fb2BEM01Y5MD0n0gjNHxM","clientrequestid":"","action":"updateDnsRecords","status":"success","statuscode":2000,"shortmessage":"DNS
+        records successful updated","longmessage":"The given DNS records for this
+        zone were updated.","responsedata":{"dnsrecords":[{"id":"405422","hostname":"@","type":"A","priority":"0","destination":"37.120.171.171","deleterecord":false,"state":"unknown"},{"id":"11758161","hostname":"docs","type":"CNAME","priority":"0","destination":"docs.example.com","deleterecord":false,"state":"unknown"},{"id":"11758160","hostname":"localhost","type":"A","priority":"0","destination":"127.0.0.1","deleterecord":false,"state":"unknown"},{"id":"11758182","hostname":"orig.nameonly.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758178","hostname":"random.fqdntest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758179","hostname":"random.fulltest","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758180","hostname":"random.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758181","hostname":"updated.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758183","hostname":"updated.testfqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758184","hostname":"updated.testfull","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"405423","hostname":"www","type":"CNAME","priority":"0","destination":"@","deleterecord":false,"state":"unknown"},{"id":"11758166","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758165","hostname":"_acme-challenge.createrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758173","hostname":"_acme-challenge.deleterecordinset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758162","hostname":"_acme-challenge.fqdn","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758163","hostname":"_acme-challenge.full","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758176","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken1","deleterecord":false,"state":"unknown"},{"id":"11758177","hostname":"_acme-challenge.listrecordset","type":"TXT","priority":"0","destination":"challengetoken2","deleterecord":false,"state":"unknown"},{"id":"11758167","hostname":"_acme-challenge.noop","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"},{"id":"11758164","hostname":"_acme-challenge.test","type":"TXT","priority":"0","destination":"challengetoken","deleterecord":false,"state":"unknown"}]}}'}
+    headers:
+      Cache-Control: ['no-store, no-cache, must-revalidate, max-age=0', 'post-check=0,
+          pre-check=0']
+      Connection: [keep-alive]
+      Content-Type: [application/json]
+      Date: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Expires: ['Tue, 03 Jul 2001 06:00:00 GMT']
+      Last-Modified: ['Fri, 19 Apr 2019 01:38:44 GMT']
+      Pragma: [no-cache]
+      Server: [nginx]
+      Strict-Transport-Security: [max-age=15768000]
+      Vary: ['Accept-Encoding,User-Agent']
+      X-Frame-Options: [SAMEORIGIN]
+      content-length: ['3220']
+    status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
Hi,

I added a Provider for netcup.de and added test cassette following the instructions in CONTRIBUTING.md. Notable quirks:

- TTL can not be configured for individual records but only for the entire zone as far as I understand, so I had to skip this test.
- the updateDnsRecords API is used to update/delete records and requires to pass type/hostname/destination in addition to ID - even if you just want to delete. This means one has to query these fields first (which is somewhat prone to race conditions, but let's hope we're the only ones modifying our own dns records at the same time;)

Best, Thomas