### PR TITLE
Dropping support for Python 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,6 @@ jobs:
     <<: *shared
     docker:
       - image: python:2.7-slim
-  "python-3.4":
-    <<: *shared
-    docker:
-      - image: python:3.4-slim
   "python-3.5":
     <<: *shared
     docker:
@@ -54,7 +50,6 @@ workflows:
   build:
     jobs:
       - "python-2.7"
-      - "python-3.4"
       - "python-3.5"
       - "python-3.6"
       - "python-3.7-cover"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Next, you should add yourself to the [CODEOWNERS file](https://github.com/Analog
 Please keep in mind the following:
 
 - `lexicon` is designed to work with multiple versions of python. That means
-your code will be tested against python 2.7, 3.4, 3.5
+your code will be tested against python 2.7, 3.5, 3.6 and 3.7
 - any provider specific dependenices should be added to the `setup.py` file,
  under the `extra_requires` heading. The group name should be the name of the
  provider. eg:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python27"
 
 build: off

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Python 3.4 is EOL. This PR removes support for this version on Lexicon, in favor of Python 3.5 for the 3.x branch.

I will make appropriate corrections on Certbot about DNS plugins once this PR is merged.

cc @bmw