### PR TITLE
Failsafe list of records when some content is missing

### DIFF
--- a/lexicon/providers/yandex.py
+++ b/lexicon/providers/yandex.py
@@ -73,7 +73,7 @@ class Provider(BaseProvider):
                     'type': record['type'],
                     'name': "{0}.{1}".format(record['subdomain'], self.domain_id),
                     'ttl': record['ttl'],
-                    'content': record['content'],
+                    'content': record.get('content'),
                     'id': record['record_id']
                 }
                 records.append(processed_record)


### PR DESCRIPTION
Revealed with https://github.com/adferrand/docker-letsencrypt-dns/issues/58

This PR allows listing records to not fail when the `content` key is not present in some records. 