### PR TITLE
Add support for Dynu.com DNS/DDNS service

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -29,6 +29,7 @@ lexicon/providers/dnsmadeeasy.py    @analogj @nydr
 lexicon/providers/dnspark.py        @analogj
 lexicon/providers/dnspod.py         @analogj
 lexicon/providers/dreamhost.py      @chhsiao1981
+lexicon/providers/dynu.py           @HerrFolgreich
 lexicon/providers/easydns.py        @analogj
 lexicon/providers/easyname.py       @astzweig @rqelibari
 lexicon/providers/euserv.py			@mschoettle

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The current supported providers are:
 - DNSPark ([docs](https://dnspark.zendesk.com/entries/31210577-REST-API-DNS-Documentation))
 - DNSPod ([docs](https://support.dnspod.cn/Support/api))
 - Dreamhost ([docs](https://help.dreamhost.com/hc/en-us/articles/217560167-API_overview))
+- Dynu ([docs](https://www.dynu.com/Support/API))
 - EasyDNS ([docs](http://docs.sandbox.rest.easydns.net/))
 - Easyname ([docs](https://www.easyname.com/en))
 - EUserv ([docs](https://support.euserv.com/api-doc/))
@@ -98,7 +99,6 @@ Potential providers are as follows. If you would like to contribute one, follow 
 - ~~DurableDNS ([docs](https://durabledns.com/wiki/doku.php/ddns))~~ <sub>Can't set TXT records</sub>
 - cyon.ch
 - Dyn ([docs](https://help.dyn.com/dns-api-knowledge-base/)) :dollar: <sub>requires paid account</sub>
-- Dynu
 - EntryDNS ([docs](https://entrydns.net/help)) :dollar: <sub>requires paid account</sub>
 - FreeDNS ([docs](https://freedns.afraid.org/scripts/freedns.clients.php))
 - Host Virtual DNS ([docs](https://github.com/hostvirtual/hostvirtual-python-sdk/blob/master/hostvirtual.py)) :dollar: <sub>requires paid account</sub>

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -1,0 +1,62 @@
+"""Module provider for Dynu.com"""
+from __future__ import absolute_import
+import json
+import logging
+
+import requests
+from lexicon.providers.base import Provider as BaseProvider
+
+
+LOGGER = logging.getLogger(__name__)
+
+NAMESERVER_DOMAINS = ['dynu.com']
+
+
+def provider_parser(subparser):
+    """Module provider for Dynu.com"""
+    subparser.add_argument(
+        "--auth-token", help="specify api key for authentication")
+
+
+class Provider(BaseProvider):
+    """Provider class for Dynu.com"""
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        self.domain_id = None
+        self.api_endpoint = 'https://api.dynu.com/v2'
+
+    def _authenticate(self):
+        pass
+
+    # Create record. If record already exists with the same content, do nothing.
+    def _create_record(self, rtype, name, content):
+        pass
+
+    # List all records. Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # If possible filter during the query, otherwise filter after response is received.
+    def _list_records(self, rtype=None, name=None, content=None):
+        pass
+
+    # Create or update a record.
+    def _update_record(self, identifier, rtype=None, name=None, content=None):
+        pass
+
+    # Delete an existing record.
+    # If record does not exist, do nothing.
+    def _delete_record(self, identifier=None, rtype=None, name=None, content=None):
+        pass
+
+    # Helpers
+    def _request(self, action='GET', url='/', data=None, query_params=None):
+        if data is None:
+            data = {}
+        # Dynu API does not respond to query parameters at all, so we ignore them
+        response = requests.request(action, self.api_endpoint + url, data=json.dumps(data),
+                                    headers={
+                                        'API-Key': self._get_provider_option('auth_token'),
+                                        'Accept': 'application/json',
+                                        'Content-Type': 'application/json'
+                                    })
+        response.raise_for_status()
+        return response.json()

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -26,7 +26,12 @@ class Provider(BaseProvider):
         self.api_endpoint = 'https://api.dynu.com/v2'
 
     def _authenticate(self):
-        pass
+        data = self._get('/dns')
+        domains = data['domains']
+        for domain in domains:
+            if domain['name'] is self.domain:
+                self.domain_id = domain['id']
+                break
 
     # Create record. If record already exists with the same content, do nothing.
     def _create_record(self, rtype, name, content):

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -65,9 +65,9 @@ class Provider(BaseProvider):
         if content:
             records = [record for record in records if record['content'] == content]
 
-        removed_records = len_records_all - len(records)
-        if removed_records:
-            LOGGER.debug('list_records: removed %d, total %d', removed_records, len_records_all)
+        len_removed = len_all - len(records)
+        if len_removed:
+            LOGGER.debug('list_records: removed %d, total %d', len_removed, len_all)
 
         LOGGER.debug('list_records: %s', records)
         return records

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -124,7 +124,7 @@ class Provider(BaseProvider):
         LOGGER.debug('delete_records: %s', delete_record_id)
 
         for record_id in delete_record_id:
-            self._delete('/dns/{0}/record'.format(record_id))
+            self._delete('/dns/{0}/record/{1}'.format(self.domain_id, record_id))
 
         LOGGER.debug('delete_record: %s', True)
         return True

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -103,8 +103,8 @@ class Provider(BaseProvider):
                 new_name = self._relative_name(name).lower()
                 if orig_name != new_name:
                     LOGGER.info(
-                        "Cannot change node name from {0} to {1}, deleting {2} and creating new"
-                        .format(orig_name, new_name, identifier)
+                        "Cannot change node name from %s to %s, deleting %s and creating new",
+                        orig_name, new_name, identifier
                     )
                     self._delete_record(identifier)
                     return self._create_record(rtype, name, content)
@@ -152,7 +152,7 @@ class Provider(BaseProvider):
         if data:
             data = json.dumps(data)
 
-        LOGGER.debug('Request: {0} {1} with data {2}'.format(action, url, data))
+        LOGGER.debug('Request: %s %s with data %s', action, url, data)
 
         response = requests.request(action, self.api_endpoint + url, data=data,
                                     headers={
@@ -160,7 +160,7 @@ class Provider(BaseProvider):
                                         'Accept': 'application/json',
                                         'Content-Type': 'application/json'
                                     })
-        LOGGER.debug('Response: {0}'.format(response))
+        LOGGER.debug('Response: %s', response)
         # if the request fails for any reason, throw an error.
         if response.status_code == 503:
             raise RuntimeError(

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -140,6 +140,6 @@ class Provider(BaseProvider):
             'id': record['id'],
             'type': record['recordType'],
             'name': record['hostname'],
-            'content': record['textData'],
+            'content': record['content'],
             'ttl': record['ttl'],
         }

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -37,10 +37,11 @@ class Provider(BaseProvider):
     def _create_record(self, rtype, name, content):
         record = {
             'recordType': rtype,
-            'nodeName': self._relative_name(name),
             'textData': content,
             'state': True,
         }
+        if name:
+            record['nodeName'] = self._relative_name(name)
 
         if self._get_lexicon_option('ttl'):
             record['ttl'] = self._get_lexicon_option('ttl')

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -42,16 +42,17 @@ class Provider(BaseProvider):
         if self._get_lexicon_option('ttl'):
             record['ttl'] = self._get_lexicon_option('ttl')
 
+        created = False
         try:
             payload = self._post('/dns/{0}/record'.format(self.domain_id), record)
+            created = self._from_dynu_record(payload)
         except requests.exceptions.HTTPError as error:
             # HTTP 501 is expected when a record with the same type and content is sent to the
             # server.
             if error.response.status_code == 501:
-                pass
+                created = True
             else:
                 raise error
-        created = self._from_dynu_record(payload)
         LOGGER.debug('create_record: %s', created)
         return created
 

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -112,7 +112,11 @@ class Provider(BaseProvider):
             records = {identifier: self._to_dynu_record(rtype, None, content)}
 
         for ident, rec in records.items():
-            add_rec = self._to_dynu_record(rec['type'], self._relative_name(rec['name']), rec['content'])
+            add_rec = self._to_dynu_record(
+                rec['type'],
+                self._relative_name(rec['name']),
+                rec['content']
+            )
             payload = self._post('/dns/{0}/record/{1}'.format(self.domain_id, ident), add_rec)
             update = self._from_dynu_record(payload)
             LOGGER.debug('update_record: %s', update)
@@ -138,8 +142,7 @@ class Provider(BaseProvider):
                 if error.response.status_code == 501:
                     LOGGER.info("delete_record: {0} does not exist".format(record_id))
                     continue
-                else:
-                    raise error
+                raise error
 
         return True
 
@@ -153,9 +156,9 @@ class Provider(BaseProvider):
 
         response = requests.request(action, self.api_endpoint + url, data=data,
                                     headers={
-                                    'API-Key': self._get_provider_option('auth_token'),
-                                    'Accept': 'application/json',
-                                    'Content-Type': 'application/json'
+                                        'API-Key': self._get_provider_option('auth_token'),
+                                        'Accept': 'application/json',
+                                        'Content-Type': 'application/json'
                                     })
         LOGGER.debug('Response: {0}'.format(response))
         # if the request fails for any reason, throw an error.
@@ -224,7 +227,7 @@ class Provider(BaseProvider):
 
         # format the content as noted in the spec, e.g. take everything
         # in the raw DNS response after the record type, and remove quotations
-        # Example: 
+        # Example:
         #   example.com. 120 IN TXT \"txt-value=thisIsATest\"
         # Becomes:
         #   txt-value=thisIsATest
@@ -261,7 +264,13 @@ class Provider(BaseProvider):
             'MX':    (lambda: {'priority': cnt_split[0], 'host': cnt_split[1]}),
             'NS':    (lambda: {'host': content}),
             'PTR':   (lambda: {'host': content}),
-            'SRV':   (lambda: {'priority': cnt_split[0], 'weight': cnt_split[1], 'port': cnt_split[2], 'host': cnt_split[3]}),
+            'SRV': (lambda: {
+                'priority': cnt_split[0],
+                'weight': cnt_split[1],
+                'port': cnt_split[2],
+                'host': cnt_split[3]
+                }
+            ),
             'TXT':   (lambda: {'textData': content}),
         }.get(rtype, lambda: {})())
         return output

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -54,7 +54,7 @@ class Provider(BaseProvider):
             }
             records.append(processed_record)
 
-        len_records_all = len(records)
+        len_all = len(records)
 
         if rtype:
             records = [record for record in records if record['type'] == rtype]

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -35,7 +35,27 @@ class Provider(BaseProvider):
 
     # Create record. If record already exists with the same content, do nothing.
     def _create_record(self, rtype, name, content):
-        pass
+        record = {
+            'recordType': rtype,
+            'nodeName': self._relative_name(name),
+            'textData': content,
+            'state': True,
+        }
+
+        if self._get_lexicon_option('ttl'):
+            record['ttl'] = self._get_lexicon_option('ttl')
+
+        try:
+            self._post('/dns/{0}/record'.format(self.domain_id), record)
+        except requests.exceptions.HTTPError as error:
+            # HTTP 501 is expected when a record with the same type and content is sent to the
+            # server.
+            if error.response.status_code == 501:
+                pass
+            else:
+                raise error
+        LOGGER.debug('create_record: %s', True)
+        return True
 
     # List all records. Return an empty list if no records found
     # type, name and content are used to filter records.

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -32,6 +32,8 @@ class Provider(BaseProvider):
             if domain['name'].lower() == self.domain.lower():
                 self.domain_id = domain['id']
                 break
+        if not self.domain_id:
+            raise Exception('No matching domain found')
 
     # Create record. If record already exists with the same content, do nothing.
     def _create_record(self, rtype, name, content):

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -29,7 +29,7 @@ class Provider(BaseProvider):
         data = self._get('/dns')
         domains = data['domains']
         for domain in domains:
-            if domain['name'] == self.domain:
+            if domain['name'].lower() == self.domain.lower():
                 self.domain_id = domain['id']
                 break
 

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -120,10 +120,10 @@ class Provider(BaseProvider):
 
     # Helpers
     def _request(self, action='GET', url='/', data=None, query_params=None):
-        if data is None:
-            data = {}
+        if data:
+            data = json.dumps(data)
         # Dynu API does not respond to query parameters at all, so we ignore them
-        response = requests.request(action, self.api_endpoint + url, data=json.dumps(data),
+        response = requests.request(action, self.api_endpoint + url, data=data,
                                     headers={
                                         'API-Key': self._get_provider_option('auth_token'),
                                         'Accept': 'application/json',

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -37,13 +37,7 @@ class Provider(BaseProvider):
 
     # Create record. If record already exists with the same content, do nothing.
     def _create_record(self, rtype, name, content):
-        record = {
-            'recordType': rtype,
-            'textData': content,
-            'state': True,
-        }
-        if name:
-            record['nodeName'] = self._relative_name(name)
+        record = self._to_dynu_record(rtype, name, content)
 
         if self._get_lexicon_option('ttl'):
             record['ttl'] = self._get_lexicon_option('ttl')
@@ -57,7 +51,7 @@ class Provider(BaseProvider):
                 pass
             else:
                 raise error
-        created = self._format_record(payload)
+        created = self._from_dynu_record(payload)
         LOGGER.debug('create_record: %s', created)
         return created
 
@@ -69,7 +63,7 @@ class Provider(BaseProvider):
 
         records = []
         for record in payload['dnsRecords']:
-            processed_record = self._format_record(record)
+            processed_record = self._from_dynu_record(record)
             records.append(processed_record)
 
         len_all = len(records)
@@ -92,14 +86,10 @@ class Provider(BaseProvider):
 
     # Create or update a record.
     def _update_record(self, identifier, rtype=None, name=None, content=None):
-        record = {
-            'recordType': rtype,
-            'name': name,
-            'content': content,
-        }
+        record = self._to_dynu_record(rtype, name, content)
 
         payload = self._post('/dns/{0}/record/{1}'.format(self.domain_id, identifier), record)
-        update = self._format_record(payload)
+        update = self._from_dynu_record(payload)
         LOGGER.debug('update_record: %s', update)
         return update
 
@@ -137,11 +127,80 @@ class Provider(BaseProvider):
 
     # Takes a Dynu.com record and puts it into lexicon-shape
     @staticmethod
-    def _format_record(record):
+    def _from_dynu_record(record):
+        rtype = record['recordType']
+        options = {
+            'enabled': record['state'],
+            'lastUpdate': record['updatedOn'],
+        }
+
+        # map additional fields depending on the record type
+        # the result takes the record type as key, and all options of the
+        # matching key in the following dict as dict of values,
+        # e.g.
+        # 'options': {
+        #     'CNAME': {
+        #         'host': 'example.com'
+        #     }
+        # }
+        options.update({rtype: {
+            'A': {'ipv4': record['ipv4Address'], 'group': record['group']},
+            'AAAA': {'ipv6': record['ipv6Address'], 'group': record['group']},
+            'CNAME': {'host': record['host']},
+            'LOC': {
+                'lat': record['latitude'],
+                'long': record['longitude'],
+                'alt': {record['altitude']},
+                'size': {record['size']},
+                'hPrec': {record['horizontalPrecision']},
+                'vPrec': {record['verticalPrecision']},
+            },
+            'MX': {'host': record['host'], 'priority': record['priority']},
+            'NS': {'host': record['host']},
+            'PTR': {'host': record['host']},
+            'SPF': {'data': record['textData']},
+            'SRV': {'host': record['host'], 'priority': record['priority'], 'weight': record['weight']},
+            'TXT': {'data': record['textData']},
+        }[rtype]})
+
+        # format the content as noted in the spec, e.g. take everything
+        # in the raw DNS response after the record type, and remove quotations
+        # Example: 
+        #   example.com. 120 IN TXT \"txt-value=thisIsATest\"
+        # Becomes:
+        #   txt-value=thisIsATest
+        content = record['content'].split(rtype)[1].strip().replace('"', '')
         return {
             'id': record['id'],
-            'type': record['recordType'],
+            'type': rtype,
             'name': record['hostname'],
-            'content': record['content'],
             'ttl': record['ttl'],
+            'content': content,
+            'options': options
         }
+
+
+    # Takes record input and puts it into a format the Dynu.com API supports
+    def _to_dynu_record(self, rtype, name, content):
+        if rtype == 'LOC':
+            raise NotImplementedError
+
+        output = {
+            'recordType': rtype,
+            'nodeName': self._relative_name(name),
+            'state': True,
+        }
+
+        cnt_split = content.split(' ')
+        output.update({
+            'A': {'ipv4Address': content},
+            'AAAA': {'ipv6Address': content},
+            'CNAME': {'host': content},
+            'MX': {'priority': cnt_split[0], 'host': cnt_split[1]},
+            'NS': {'host': content},
+            'PTR': {'host': content},
+            'SPF': {'textData': content},
+            'SRV': {'priority': cnt_split[0], 'weight': cnt_split[1], 'port': cnt_split[2], 'host': cnt_split[3]},
+            'TXT': {'textData': content},
+        }[rtype])
+        return output

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -140,7 +140,7 @@ class Provider(BaseProvider):
                 LOGGER.debug('delete_record: %s', record_id)
             except requests.exceptions.HTTPError as error:
                 if error.response.status_code == 501:
-                    LOGGER.info("delete_record: {0} does not exist".format(record_id))
+                    LOGGER.info("delete_record: %s does not exist", record_id)
                     continue
                 raise error
 
@@ -269,8 +269,7 @@ class Provider(BaseProvider):
                 'weight': cnt_split[1],
                 'port': cnt_split[2],
                 'host': cnt_split[3]
-                }
-            ),
+                }),
             'TXT':   (lambda: {'textData': content}),
         }.get(rtype, lambda: {})())
         return output

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -57,7 +57,7 @@ class Provider(BaseProvider):
                 pass
             else:
                 raise error
-        created = __class__._format_record(payload)
+        created = self._format_record(payload)
         LOGGER.debug('create_record: %s', created)
         return created
 
@@ -69,7 +69,7 @@ class Provider(BaseProvider):
 
         records = []
         for record in payload['dnsRecords']:
-            processed_record = __class__._format_record(record)
+            processed_record = self._format_record(record)
             records.append(processed_record)
 
         len_all = len(records)
@@ -99,7 +99,7 @@ class Provider(BaseProvider):
         }
 
         payload = self._post('/dns/{0}/record/{1}'.format(self.domain_id, identifier), record)
-        update = __class__._format_record(payload)
+        update = self._format_record(payload)
         LOGGER.debug('update_record: %s', update)
         return update
 

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -94,7 +94,22 @@ class Provider(BaseProvider):
 
     # Create or update a record.
     def _update_record(self, identifier, rtype=None, name=None, content=None):
-        pass
+        record = {
+            'recordType': rtype,
+            'name': name,
+            'content': content,
+        }
+
+        payload = self._post('/dns/{0}/record/{1}'.format(self.domain_id, identifier), record)
+        update = {
+            'id': payload['id'],
+            'type': payload['recordType'],
+            'name': payload['hostname'],
+            'content': payload['textData'],
+            'ttl': payload['ttl'],
+        }
+        LOGGER.debug('update_record: %s', update)
+        return update
 
     # Delete an existing record.
     # If record does not exist, do nothing.

--- a/lexicon/providers/dynu.py
+++ b/lexicon/providers/dynu.py
@@ -99,7 +99,20 @@ class Provider(BaseProvider):
     # Delete an existing record.
     # If record does not exist, do nothing.
     def _delete_record(self, identifier=None, rtype=None, name=None, content=None):
-        pass
+        delete_record_id = []
+        if not identifier:
+            records = self._list_records(rtype, name, content)
+            delete_record_id = [record['id'] for record in records]
+        else:
+            delete_record_id.append(identifier)
+
+        LOGGER.debug('delete_records: %s', delete_record_id)
+
+        for record_id in delete_record_id:
+            self._delete('/dns/{0}/record'.format(record_id))
+
+        LOGGER.debug('delete_record: %s', True)
+        return True
 
     # Helpers
     def _request(self, action='GET', url='/', data=None, query_params=None):

--- a/lexicon/tests/providers/test_dynu.py
+++ b/lexicon/tests/providers/test_dynu.py
@@ -1,6 +1,5 @@
 """Integration tests for Dynu.com"""
 from unittest import TestCase
-import json
 
 from lexicon.tests.providers.integration_tests import IntegrationTests
 

--- a/lexicon/tests/providers/test_dynu.py
+++ b/lexicon/tests/providers/test_dynu.py
@@ -1,0 +1,30 @@
+"""Integration tests for Dynu.com"""
+from unittest import TestCase
+import json
+
+from lexicon.tests.providers.integration_tests import IntegrationTests
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class DynuProviderTests(TestCase, IntegrationTests):
+    """TestCase for Dynu.com"""
+    provider_name = 'dynu'
+    domain = 'example.com'
+
+    def _filter_headers(self):
+        return ['API-Key']
+
+    def _filter_response(self, response):
+        resp = json.loads(response['body']['string'])
+        for resp_domain in resp['domains']:
+            resp_domain['name'] = 'example.com'
+            resp_domain['unicodeName'] = 'example.com'
+            resp_domain['location'] = 'lexicon-dns'
+            resp_domain['group'] = 'lexicon-dns'
+            resp_domain['ipv4Address'] = '127.0.0.1'
+            resp_domain['ipv6Address'] = '::1'
+
+        response['body']['string'] = json.dumps(resp)
+        return response

--- a/lexicon/tests/providers/test_dynu.py
+++ b/lexicon/tests/providers/test_dynu.py
@@ -17,14 +17,6 @@ class DynuProviderTests(TestCase, IntegrationTests):
         return ['API-Key']
 
     def _filter_response(self, response):
-        resp = json.loads(response['body']['string'])
-        for resp_domain in resp['domains']:
-            resp_domain['name'] = 'example.com'
-            resp_domain['unicodeName'] = 'example.com'
-            resp_domain['location'] = 'lexicon-dns'
-            resp_domain['group'] = 'lexicon-dns'
-            resp_domain['ipv4Address'] = '127.0.0.1'
-            resp_domain['ipv6Address'] = '::1'
-
-        response['body']['string'] = json.dumps(resp)
+        if response['status']['code'] not in [200, 503]:
+            return None
         return response

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:12:56.42"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:12:56.42"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:12:56.42"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "A", "state": true, "nodeName": "test", "ipv4Address": "127.0.0.1",
+      "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052991,"domainId":1024,"domainName":"example.com","nodeName":"test","hostname":"test.example.com","recordType":"A","ttl":3600,"state":true,"content":"test.example.com.
+        3600 IN A 127.0.0.1","updatedOn":"2020-03-12T22:19:19.287","location":"","ipv4Address":"127.0.0.1"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '291'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052991
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:21"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:23 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "CNAME", "state": true, "nodeName": "docs", "host": "test.example.com",
+      "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '99'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052992,"domainId":1024,"domainName":"example.com","nodeName":"docs","hostname":"docs.example.com","recordType":"CNAME","ttl":3600,"state":true,"content":"docs.example.com.
+        3600 IN CNAME test.example.com.","updatedOn":"2020-03-12T22:19:24.73","host":"test.example.com"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '292'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:24 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052992
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:29 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:30.247"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '382'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:30 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.fqdn",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052993,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.fqdn","hostname":"_acme-challenge.fqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.fqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:19:32.497","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:32 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052993
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:34 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:34.53"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:35 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.full",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052994,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.full","hostname":"_acme-challenge.full.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.full.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:19:37.373","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052994
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:38 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:39.627"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '382'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.test",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052995,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.test","hostname":"_acme-challenge.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:19:41.97","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '339'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052995
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:43 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:43"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:44 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.createrecordset",
+      "textData": "challengetoken1", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052996,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.createrecordset","hostname":"_acme-challenge.createrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.createrecordset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:19:49.563","textData":"challengetoken1"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.createrecordset",
+      "textData": "challengetoken2", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052997,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.createrecordset","hostname":"_acme-challenge.createrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.createrecordset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:19:51.357","textData":"challengetoken2"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '375'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:51 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052996
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:52 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052997
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:54 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,193 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:19:54"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:55 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.noop",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6052999,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.noop","hostname":"_acme-challenge.noop.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.noop.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:12.547","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '340'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:12 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.noop",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":501,"type":"Argument Exception","message":"Invalid."}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '67'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:18 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 501
+      message: Argument Exception
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6052999,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.noop","hostname":"_acme-challenge.noop.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.noop.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:12.547","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:20 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6052999
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -76,45 +76,6 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.noop",
-      "textData": "challengetoken", "ttl": 3600}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '115'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.23.0
-    method: POST
-    uri: https://api.dynu.com/v2/dns/1024/record
-  response:
-    body:
-      string: '{"statusCode":501,"type":"Argument Exception","message":"Invalid."}'
-    headers:
-      Cache-Control:
-      - no-store
-      Content-Length:
-      - '67'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 12 Mar 2020 22:21:18 GMT
-      Pragma:
-      - no-cache
-      Server:
-      - Dynu Web Server
-      X-Powered-By:
-      - Dynu Dynamic DNS Service
-    status:
-      code: 501
-      message: Argument Exception
-- request:
     body: null
     headers:
       Accept:
@@ -181,6 +142,156 @@ interactions:
       - application/json; charset=UTF-8
       Date:
       - Thu, 12 Mar 2020 22:21:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-06-03T21:15:08.92"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 03 Jun 2020 21:41:18 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-06-03T21:15:08.92"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '381'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 03 Jun 2020 21:41:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.noop",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '115'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6393145,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.noop","hostname":"_acme-challenge.noop.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.noop.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-06-03T21:41:37.57","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '339'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 03 Jun 2020 21:41:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6393145,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.noop","hostname":"_acme-challenge.noop.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.noop.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-06-03T21:41:37.57","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '755'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 03 Jun 2020 21:41:40 GMT
       Pragma:
       - no-cache
       Server:

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,191 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:21:17.14"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '438'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:26 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "delete.testfilt", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053000,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfilt","hostname":"delete.testfilt.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfilt.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:25.987","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:26 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053000,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfilt","hostname":"delete.testfilt.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfilt.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:25.987","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1217'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:27 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053000
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:35 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:32 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,191 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:21:41.21"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '438'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "delete.testfqdn", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053001,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfqdn","hostname":"delete.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:44.567","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053001,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfqdn","hostname":"delete.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:44.567","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1217'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:53 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053001
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:55 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:21:56 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,191 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:21:52.707"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:0 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "delete.testfull", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053002,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfull","hostname":"delete.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:59.127","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:3 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053002,"domainId":1024,"domainName":"example.com","nodeName":"delete.testfull","hostname":"delete.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:21:59.127","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1217'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:16 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053002
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:17 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,191 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:22:17"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "delete.testid", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053003,"domainId":1024,"domainName":"example.com","nodeName":"delete.testid","hostname":"delete.testid.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testid.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:22:18.037","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053003,"domainId":1024,"domainName":"example.com","nodeName":"delete.testid","hostname":"delete.testid.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"delete.testid.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:22:18.037","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1211'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:28 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053003
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:29 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:32 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,271 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:22:26.567"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:34 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.deleterecordinset",
+      "textData": "challengetoken1", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053004,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordinset","hostname":"_acme-challenge.deleterecordinset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordinset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:22:36.86","textData":"challengetoken1"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '416'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:41 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.deleterecordinset",
+      "textData": "challengetoken2", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053005,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordinset","hostname":"_acme-challenge.deleterecordinset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordinset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:22:43.007","textData":"challengetoken2"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '417'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053004,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordinset","hostname":"_acme-challenge.deleterecordinset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordinset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:22:36.86","textData":"challengetoken1"},{"id":6053005,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordinset","hostname":"_acme-challenge.deleterecordinset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordinset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:22:43.007","textData":"challengetoken2"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1673'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053004
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:50 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053005,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordinset","hostname":"_acme-challenge.deleterecordinset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordinset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:22:43.007","textData":"challengetoken2"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1273'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:52 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053005
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:53 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,270 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:22:49.02"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '438'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:22:57 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.deleterecordset",
+      "textData": "challengetoken1", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053006,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordset","hostname":"_acme-challenge.deleterecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:22:57.5","textData":"challengetoken1"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:2 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.deleterecordset",
+      "textData": "challengetoken2", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053007,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordset","hostname":"_acme-challenge.deleterecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:22:59.94","textData":"challengetoken2"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '410'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:4 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053006,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordset","hostname":"_acme-challenge.deleterecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:22:57.5","textData":"challengetoken1"},{"id":6053007,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.deleterecordset","hostname":"_acme-challenge.deleterecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.deleterecordset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:22:59.94","textData":"challengetoken2"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1659'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:8 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053006
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:10 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053007
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:23:11.4"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '437'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "ttl.fqdn", "textData":
+      "ttlshouldbe3600", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053008,"domainId":1024,"domainName":"example.com","nodeName":"ttl.fqdn","hostname":"ttl.fqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"ttl.fqdn.example.com.
+        3600 IN TXT \"ttlshouldbe3600\"","updatedOn":"2020-03-12T22:23:17.347","textData":"ttlshouldbe3600"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '342'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:22 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053008,"domainId":1024,"domainName":"example.com","nodeName":"ttl.fqdn","hostname":"ttl.fqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"ttl.fqdn.example.com.
+        3600 IN TXT \"ttlshouldbe3600\"","updatedOn":"2020-03-12T22:23:17.347","textData":"ttlshouldbe3600"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1198'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:28 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053008
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:30 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,233 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:23:30"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:31 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.listrecordset",
+      "textData": "challengetoken1", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053009,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.listrecordset","hostname":"_acme-challenge.listrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.listrecordset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:23:28.77","textData":"challengetoken1"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:33 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "_acme-challenge.listrecordset",
+      "textData": "challengetoken2", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053010,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.listrecordset","hostname":"_acme-challenge.listrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.listrecordset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:23:30.62","textData":"challengetoken2"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '404'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:35 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053009,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.listrecordset","hostname":"_acme-challenge.listrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.listrecordset.example.com.
+        3600 IN TXT \"challengetoken1\"","updatedOn":"2020-03-12T22:23:28.77","textData":"challengetoken1"},{"id":6053010,"domainId":1024,"domainName":"example.com","nodeName":"_acme-challenge.listrecordset","hostname":"_acme-challenge.listrecordset.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"_acme-challenge.listrecordset.example.com.
+        3600 IN TXT \"challengetoken2\"","updatedOn":"2020-03-12T22:23:30.62","textData":"challengetoken2"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1648'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:36 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053009
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:38 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053010
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:43 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:23:43"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:48 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "random.fqdntest", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053011,"domainId":1024,"domainName":"example.com","nodeName":"random.fqdntest","hostname":"random.fqdntest.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.fqdntest.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:23:48.203","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:53 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053011,"domainId":1024,"domainName":"example.com","nodeName":"random.fqdntest","hostname":"random.fqdntest.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.fqdntest.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:23:48.203","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1217'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:54 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053011
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:55 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:23:55"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:57 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "random.fulltest", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053012,"domainId":1024,"domainName":"example.com","nodeName":"random.fulltest","hostname":"random.fulltest.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.fulltest.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:23:54.283","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '361'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:23:59 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053012,"domainId":1024,"domainName":"example.com","nodeName":"random.fulltest","hostname":"random.fulltest.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.fulltest.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:23:54.283","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1217'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:0 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053012
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:1 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:24:01"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:3 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:4 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:23:58.7"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '437'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:5 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "random.test", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '106'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053013,"domainId":1024,"domainName":"example.com","nodeName":"random.test","hostname":"random.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:03.033","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '349'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:7 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053013,"domainId":1024,"domainName":"example.com","nodeName":"random.test","hostname":"random.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"random.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:03.033","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1205'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:9 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053013
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:13 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,75 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:24:10.687"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '872'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:17 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,269 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:24:10.687"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "orig.test", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '104'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053014,"domainId":1024,"domainName":"example.com","nodeName":"orig.test","hostname":"orig.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:20.3","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '341'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:25 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053014,"domainId":1024,"domainName":"example.com","nodeName":"orig.test","hostname":"orig.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:20.3","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1197'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:27 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record/6053014
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053014,"domainId":1024,"domainName":"example.com","nodeName":"orig.test","hostname":"orig.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:20.3","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '341'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:29 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053014
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:31 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "updated.test", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '107'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053015,"domainId":1024,"domainName":"example.com","nodeName":"updated.test","hostname":"updated.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"updated.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:31.047","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '352'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:35 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053015
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:37 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,194 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:24:33.88"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '438'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "orig.nameonly.test",
+      "textData": "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053016,"domainId":1024,"domainName":"example.com","nodeName":"orig.nameonly.test","hostname":"orig.nameonly.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.nameonly.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:37.567","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '370'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053016,"domainId":1024,"domainName":"example.com","nodeName":"orig.nameonly.test","hostname":"orig.nameonly.test.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.nameonly.test.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:37.567","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1226'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:44 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "orig.nameonly.test",
+      "textData": "challengetoken"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record/6053016
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053016,"domainId":1024,"domainName":"example.com","nodeName":"orig.nameonly.test","hostname":"orig.nameonly.test.example.com","recordType":"TXT","ttl":60,"state":true,"content":"orig.nameonly.test.example.com.
+        60 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:46.9333076+00:00","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '376'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053016
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,269 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:24:45.647"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '439'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:52 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "orig.testfqdn", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053017,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfqdn","hostname":"orig.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:49.383","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:54 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053017,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfqdn","hostname":"orig.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:49.383","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1211'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:24:56 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record/6053017
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053017,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfqdn","hostname":"orig.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:24:49.383","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:0 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053017
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:4 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "updated.testfqdn", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053018,"domainId":1024,"domainName":"example.com","nodeName":"updated.testfqdn","hostname":"updated.testfqdn.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"updated.testfqdn.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:25:06.327","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '364'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:11 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053018
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:12 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,269 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns
+  response:
+    body:
+      string: '{"statusCode":200,"domains":[{"id":1024,"name":"example.com","unicodeName":"example.com","token":"LQFTMTBQVOYUGQRFIQMU","state":"Complete","location":"lexicon","group":"lexicon","ipv4Address":"127.0.0.1","ipv6Address":"::1","ttl":120,"ipv4":true,"ipv6":true,"ipv4WildcardAlias":true,"ipv6WildcardAlias":true,"createdOn":"2019-06-16T18:26:58","updatedOn":"2020-03-12T22:25:08.87"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '438'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "orig.testfull", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053019,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfull","hostname":"orig.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:25:15.027","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"dnsRecords":[{"id":3660288,"domainId":1024,"domainName":"example.com","nodeName":"","hostname":"example.com","recordType":"SOA","ttl":120,"state":true,"content":"example.com.
+        120 IN SOA ns1.dynu.com. administrator.dynu.com. 0 1800 300 86400 300","updatedOn":"2019-06-16T18:26:59","masterName":"ns1.dynu.com","responsibleName":"administrator.dynu.com","refresh":1800,"retry":300,"expire":86400,"negativeTTL":300},{"id":6053019,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfull","hostname":"orig.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:25:15.027","textData":"challengetoken"}]}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '1211'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/1024/record/6053019
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053019,"domainId":1024,"domainName":"example.com","nodeName":"orig.testfull","hostname":"orig.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"orig.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:25:15.027","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:26 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053019
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:28 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"recordType": "TXT", "state": true, "nodeName": "updated.testfull", "textData":
+      "challengetoken", "ttl": 3600}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '111'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://api.dynu.com/v2/dns/1024/record
+  response:
+    body:
+      string: '{"statusCode":200,"id":6053021,"domainId":1024,"domainName":"example.com","nodeName":"updated.testfull","hostname":"updated.testfull.example.com","recordType":"TXT","ttl":3600,"state":true,"content":"updated.testfull.example.com.
+        3600 IN TXT \"challengetoken\"","updatedOn":"2020-03-12T22:25:26.267","textData":"challengetoken"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '364'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:31 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://api.dynu.com/v2/dns/1024/record/6053021
+  response:
+    body:
+      string: '{"statusCode":200}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '18'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:25:33 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Hello again,

I'm trying my best to support Dynu.com.

Though currently I'm stuck on seeding the integration test fixtures as
1. I'm running into undocumented rate limiting (resulting in HTTP 503) 
2. The tests to add several records on either the `example.com` domain or with `127.0.0.1` fail serverside because the validation is (rightfully so) quite picky.

So the question is now: do I disable several tests, mock the data by hand (with `example.com` et al.) or change the test cases?

Also, #461 is not completely irrelevant, but won't affect this PR, just the handling of the CLI.

Best,
Chris