### PR TITLE
Fix nslookup resolution on Windows.

### DIFF
--- a/lexicon/providers/auto.py
+++ b/lexicon/providers/auto.py
@@ -47,7 +47,7 @@ def _get_ns_records_domains_for_domain(domain):
 def _get_ns_records_for_domain(domain):
     # Available both for Windows and Linux (if dnsutils is installed for the latter)
     try:
-        output = subprocess.check_output(['nslookup', '-querytype=NS', domain],
+        output = subprocess.check_output(['nslookup', '-querytype=NS', domain + "."],
                                          stderr=subprocess.STDOUT, universal_newlines=True)
     except subprocess.CalledProcessError as error:
         if 'NXDOMAIN' in error.output:


### PR DESCRIPTION
Windows (at least on my Insider build 19041) requires domain to be absolute (dot at the end) in the `nslookup` command, otherwise it adds local primary domain suffix before looking-up the domain.

Tested both on Linux and Windows.

### Windows

Relative domain:
```
#> nslookup -querytype=NS ovh.co.uk
Server:  xxx.home.oldium.net
Address:  xxxx:xxxx:xxxx:1::1

Non-authoritative answer:
ovh.co.uk.oldium.net    canonical name = oldium.net
oldium.net      nameserver = ns3.gransy.com
...
```

Absolute domain:
```
#> nslookup -querytype=NS ovh.co.uk.
Server:  xxxx.home.oldium.net
Address:  xxxx:xxxx:xxxx:1::1

Non-authoritative answer:
ovh.co.uk       nameserver = dns10.ovh.net
ovh.co.uk       nameserver = ns10.ovh.net
...
```

### Linux (Ubuntu 18.04 LTS)

Relative domain:
```
#> nslookup -querytype=NS ovh.co.uk
Server:         172.27.144.1
Address:        172.27.144.1#53

Non-authoritative answer:
ovh.co.uk       nameserver = dns10.ovh.net.
ovh.co.uk       nameserver = ns10.ovh.net.
```

Absolute domain:
```
#> nslookup -querytype=NS ovh.co.uk.
Server:         172.27.144.1
Address:        172.27.144.1#53

Non-authoritative answer:
ovh.co.uk       nameserver = dns10.ovh.net.
ovh.co.uk       nameserver = ns10.ovh.net.
```

See also [answer about absolute and relative domain names](https://serverfault.com/a/803037).