### PR TITLE
Decode also private domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ Lexicon attempts to standardize authentication around the following CLI flags:
 You can see all the `--auth-*` flags for a specific service by reading the DNS service specific help: `lexicon cloudflare -h`
 
 ### Environmental Variables
+
+#### Authentication
+
 Instead of providing Authentication information via the CLI, you can also specify them via Environmental Variables.
 Every DNS service and auth flag maps to an Environmental Variable as follows: `LEXICON_{DNS Provider Name}_{Auth Type}`
 
@@ -242,6 +245,17 @@ you could instead set the `LEXICON_CLOUDFLARE_USERNAME` and `LEXICON_CLOUDFLARE_
 If you've got a subdomain delegation configured and need records configured within that (eg, you're trying to set `test.foo.example.com` where `foo.example.com` is configured as a separate zone), set `LEXICON_DELEGATED` to the delegated domain.
 
     LEXICON_DELEGATED=foo.example.com
+
+#### TLD Cache
+
+The [tldextract](https://pypi.org/project/tldextract/) library is used by Lexicon to find the actual domain name
+from the provided FQDN (eg. `domain.net` is the actual domain in `www.domain.net`). Lexicon stores `tldextract` cache
+by default in `~/.lexicon_tld_set` where `~` is the current user's home directory. You can change this path using
+the `LEXICON_TLDEXTRACT_CACHE` environment variable.
+
+For instance, to store `tldextract` cache in `/my/path/to/tld_cache`, you can invoke Lexicon like this from a Linux shell:
+
+    LEXICON_TLDEXTRACT_CACHE=/my/path/to/tld_cache lexicon myprovider create www.example.net TXT ...
 
 ### Letsencrypt Instructions
 Lexicon has an example [dehydrated hook file](examples/dehydrated.default.sh) that you can use for any supported provider.

--- a/lexicon/client.py
+++ b/lexicon/client.py
@@ -1,6 +1,7 @@
 """Main module of Lexicon. Defines the Client class, that holds all Lexicon logic."""
 from __future__ import absolute_import
 import importlib
+import os
 
 import tldextract
 
@@ -10,6 +11,9 @@ from lexicon.config import (
     legacy_config_resolver, non_interactive_config_resolver,
 )
 
+TLDEXTRACT_CACHE_FILE_DEFAULT = os.path.join('~', '.lexicon_tld_set')
+TLDEXTRACT_CACHE_FILE = os.path.expanduser(os.environ.get("LEXICON_TLDEXTRACT_CACHE",
+                                                          TLDEXTRACT_CACHE_FILE_DEFAULT))
 
 class ProviderNotAvailableError(Exception):
     """
@@ -38,7 +42,9 @@ class Client(object):  # pylint: disable=useless-object-inheritance,too-few-publ
         runtime_config = {}
 
         # Process domain, strip subdomain
-        domain_parts = tldextract.extract(
+        domain_extractor = tldextract.TLDExtract(cache_file=TLDEXTRACT_CACHE_FILE,
+                                                 include_psl_private_domains=True)
+        domain_parts = domain_extractor(
             self.config.resolve('lexicon:domain'))
         runtime_config['domain'] = '{0}.{1}'.format(
             domain_parts.domain, domain_parts.suffix)


### PR DESCRIPTION
Fixes #343
Fixes #461

The tldextract library ignores private domains, so domain test.us.com is wrongly extracted as subdomain=test, domain=us and suffix=com.

When allowing private domains, the extraction of test.us.com looks like subdomain=<empty>, domain=test and suffix=us.com.

Usage of `LEXICON_TLDEXTRACT_CACHE` environment variable needs to be documented somehow.

I am not sure whether this is how it should be fixed. Another workaround for private domain name resolution issue is mentioned in issue #461.