### PR TITLE
Give a flag to set explicitly the zone ID and avoid unscoped API tokens

### DIFF
--- a/lexicon/tests/providers/test_cloudflare.py
+++ b/lexicon/tests/providers/test_cloudflare.py
@@ -18,5 +18,7 @@ class CloudflareProviderTests(TestCase, IntegrationTests):
     # We do not want to have "placeholder_auth_username" as default value for `--auth-username`
     # if Bearer tokens are used to execute the tests, because the non-emptiness of this flags
     # triggers interpretation of `--auth-key` as a Global API key.
+    # Similarly for `--zone-id`, we want to control when its value is not empty, because
+    # it will change the logic of the authentication process.
     def _test_fallback_fn(self):
-        return lambda x: 'placeholder_' + x if x != 'auth_username' else ''
+        return lambda x: 'placeholder_' + x if x not in ('auth_username', 'zone_id') else ''


### PR DESCRIPTION
We will certainly remove this workaround once CloudFlare improved its API.