### PR TITLE
Remove obsolete dependencies for Hetzner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ extras_require = {
     'transip': ['transip>=0.3.0'],
     'plesk': ['xmltodict'],
     'henet': ['beautifulsoup4'],
-    'hetzner': ['dnspython>=1.15.0', 'beautifulsoup4', 'html5lib'],
     'easyname': ['beautifulsoup4'],
     'localzone': ['localzone'],
     'gratisdns': ['beautifulsoup4'],


### PR DESCRIPTION
As the old Hetzner integration was removed we don't need the additional dependencies anymore.
The new dns.hetzner.com integration only uses common dependencies (like requests and future).

This change removes dependency on dnspython and html5lib, whereas
beautifulsoup is still used by other integrations.
