### PR TITLE
Allow updating gandi rrset ttl

### DIFF
--- a/lexicon/providers/gandi.py
+++ b/lexicon/providers/gandi.py
@@ -98,6 +98,8 @@ class Provider(BaseProvider):
                 self.domain_id, self._relative_name(name), rtype)
             if current_values:
                 record = {'rrset_values': current_values + [content]}
+                if self._get_lexicon_option('ttl'):
+                    record['rrset_ttl'] = self._get_lexicon_option('ttl')
                 self._put(url, record)
             else:
                 record = {'rrset_values': [content]}


### PR DESCRIPTION
Previously, a rrset ttl could be set only when creating a new record,
whereas with this change, now a new ttl value can be specified.